### PR TITLE
Add configure option --with-default-trust-store-file

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -109,6 +109,11 @@
 
        gtkmm2のかわりにgtkmm3を使用する。
 
+    --with-default-trust-store-file=FILE
+
+       指定したFILEをデフォルトのX.509証明書として使います。
+       注意: 'no'を指定するとオプション不使用と解釈されファイル名として扱われません。
+
 * メモ
 
   最近のディストリビューションの場合は autogen.sh よりも autoreconf -i の方を推奨。

--- a/configure.ac
+++ b/configure.ac
@@ -509,4 +509,20 @@ AC_ARG_WITH(pangolayout,[ --with-pangolayout    (use pangolayout)],
        fi ])
 
 
+dnl
+dnl checking default trust store file
+dnl
+AC_MSG_CHECKING(for --with-default-trust-store-file)
+AC_ARG_WITH(default-trust-store-file,
+  [AS_HELP_STRING([--with-default-trust-store-file=FILE],
+                  [use the given file default trust store])],
+  [with_default_trust_store_file="$withval"],
+  [with_default_trust_store_file=no])
+AC_MSG_RESULT($with_default_trust_store_file)
+
+AS_IF([test "x$with_default_trust_store_file" != xno],
+      [AC_DEFINE_UNQUOTED([DEFAULT_TRUST_STORE_FILE],
+                          ["$with_default_trust_store_file"], [use the given file default trust store])])
+
+
 AC_OUTPUT(Makefile src/Makefile src/skeleton/Makefile src/jdlib/Makefile src/dbtree/Makefile src/dbimg/Makefile  src/bbslist/Makefile src/board/Makefile src/article/Makefile src/image/Makefile src/message/Makefile src/history/Makefile src/config/Makefile src/icons/Makefile src/sound/Makefile src/xml/Makefile src/control/Makefile )

--- a/src/jdlib/ssl.cpp
+++ b/src/jdlib/ssl.cpp
@@ -74,7 +74,11 @@ bool JDSSL::connect( const int soc, const char *host )
 #if GNUTLS_VERSION_NUMBER >= 0x030406
     ret = gnutls_certificate_allocate_credentials( &m_cred );
     assert( ret == GNUTLS_E_SUCCESS );
+#ifdef DEFAULT_TRUST_STORE_FILE
+    ret = gnutls_certificate_set_x509_trust_file( m_cred, DEFAULT_TRUST_STORE_FILE, GNUTLS_X509_FMT_PEM );
+#else
     ret = gnutls_certificate_set_x509_system_trust( m_cred );
+#endif
     assert( ret >= 0 );
 
     ret = gnutls_server_name_set( m_session, GNUTLS_NAME_DNS, host, strlen( host ) );


### PR DESCRIPTION
指定したファイルをデフォルトのX.509証明書として使うオプションを追加する。
これはgnutls_certificate_set_x509_system_trust()が期待通りに動作しない
環境での利用を想定している。
NOTE: 'no'を指定するとオプション不使用と解釈されファイル名として扱われない。

修正にあたり不具合報告や動作検証をしていただきありがとうございました。
https://mao.5ch.net/test/read.cgi/linux/1540656394/701-766

### 廃案の理由
特定のディストリで発生したライブラリの読み込みが衝突する問題であった。
https://mao.5ch.net/test/read.cgi/linux/1540656394/961
