### PR TITLE
[WIP] Fix large resnumber

### DIFF
--- a/src/article/layouttree.cpp
+++ b/src/article/layouttree.cpp
@@ -28,6 +28,8 @@ enum
     MAX_IMGITEM = 512 // struct IMGDATA.item[] のサイズ
 };
 
+static_assert( kExpectedResNumber <= kMaxResNumber, "kExpectedResNumber must be less than kMaxResNumber." );
+
 
 // 埋め込み画像用構造体
 namespace ARTICLE
@@ -64,7 +66,7 @@ LayoutTree::LayoutTree( const std::string& url, const bool show_abone, const boo
 #ifdef _DEBUG
     std::cout << "LayoutTree::LayoutTree : url = " << url << " show_abone = " << m_show_abone << std::endl;
 #endif    
-    m_vec_header.reserve( MAX_RESNUMBER ) ;
+    m_vec_header.reserve( kExpectedResNumber ) ;
     m_article = DBTREE::get_article( m_url );
     assert( m_article );
 

--- a/src/article/layouttree.cpp
+++ b/src/article/layouttree.cpp
@@ -66,7 +66,7 @@ LayoutTree::LayoutTree( const std::string& url, const bool show_abone, const boo
 #ifdef _DEBUG
     std::cout << "LayoutTree::LayoutTree : url = " << url << " show_abone = " << m_show_abone << std::endl;
 #endif    
-    m_vec_header.reserve( kExpectedResNumber ) ;
+    m_header_map.reserve( kExpectedResNumber ) ;
     m_article = DBTREE::get_article( m_url );
     assert( m_article );
 
@@ -89,7 +89,7 @@ void LayoutTree::clear()
 {
     m_heap.clear();
 
-    m_vec_header.clear();
+    m_header_map.clear();
 
     m_last_header = NULL;
     m_max_res_number = 0;
@@ -326,7 +326,7 @@ void LayoutTree::append_node( DBTREE::NODE* node_header, const bool joint )
         header->res_number = res_number;
         header->node = node_header;
         if( res_number > m_max_res_number ) m_max_res_number = res_number;
-        m_vec_header[ res_number ] = header;
+        m_header_map[ res_number ] = header;
 
         while( dom ){
             m_last_dom_attr = dom->attr;
@@ -474,7 +474,7 @@ void LayoutTree::append_abone_node( DBTREE::NODE* node_header )
     if( ! m_show_abone && m_article->get_abone_transparent() ) return;
 
     LAYOUT* head = create_layout_header();
-    m_vec_header[ res_number ] = head;
+    m_header_map[ res_number ] = head;
 
     head->res_number = res_number;
 
@@ -554,10 +554,10 @@ const LAYOUT* LayoutTree::get_header_of_res_const( const int number ){ return ge
 
 LAYOUT* LayoutTree::get_header_of_res( const int number )
 {
-    if( m_vec_header.empty() || !m_vec_header.count( number ) ) return NULL;
+    if( m_header_map.empty() || !m_header_map.count( number ) ) return nullptr;
     if( number > m_max_res_number || number <= 0 ) return NULL;
 
-    return m_vec_header[ number ];
+    return m_header_map[ number ];
 }
 
 

--- a/src/article/layouttree.cpp
+++ b/src/article/layouttree.cpp
@@ -55,7 +55,6 @@ using namespace ARTICLE;
 LayoutTree::LayoutTree( const std::string& url, const bool show_abone, const bool show_multispace )
     : m_heap( SIZE_OF_HEAP ),
       m_url( url ),
-      m_vec_header( NULL ),
       m_local_nodetree( 0 ),
       m_separator_header( NULL ),
       m_show_abone( show_abone ),
@@ -65,7 +64,7 @@ LayoutTree::LayoutTree( const std::string& url, const bool show_abone, const boo
 #ifdef _DEBUG
     std::cout << "LayoutTree::LayoutTree : url = " << url << " show_abone = " << m_show_abone << std::endl;
 #endif    
-
+    m_vec_header.reserve( MAX_RESNUMBER ) ;
     m_article = DBTREE::get_article( m_url );
     assert( m_article );
 
@@ -88,8 +87,8 @@ void LayoutTree::clear()
 {
     m_heap.clear();
 
-    m_vec_header = NULL;
-    
+    m_vec_header.clear();
+
     m_last_header = NULL;
     m_max_res_number = 0;
 
@@ -283,7 +282,6 @@ LAYOUT* LayoutTree::create_layout_sssp( const char* link )
     return tmplayout;
 }
 
-
 //
 // nodetreeのノード構造をコピーし、レイアウトツリーの一番最後に加える
 //
@@ -326,7 +324,6 @@ void LayoutTree::append_node( DBTREE::NODE* node_header, const bool joint )
         header->res_number = res_number;
         header->node = node_header;
         if( res_number > m_max_res_number ) m_max_res_number = res_number;
-        if( ! m_vec_header ) m_vec_header = ( LAYOUT** ) m_heap.heap_alloc( sizeof( LAYOUT* ) * MAX_RESNUMBER );
         m_vec_header[ res_number ] = header;
 
         while( dom ){
@@ -466,7 +463,6 @@ void LayoutTree::append_abone_node( DBTREE::NODE* node_header )
 {
     const int res_number = node_header->id_header;
     if( res_number > m_max_res_number ) m_max_res_number = res_number;
-    if( ! m_vec_header ) m_vec_header = ( LAYOUT** ) m_heap.heap_alloc( sizeof( LAYOUT* ) * MAX_RESNUMBER );
 
 #ifdef _DEBUG
     std::cout << "LayoutTree::append_abone_node num = " << res_number << std::endl;
@@ -556,7 +552,7 @@ const LAYOUT* LayoutTree::get_header_of_res_const( const int number ){ return ge
 
 LAYOUT* LayoutTree::get_header_of_res( const int number )
 {
-    if( ! m_vec_header ) return NULL;
+    if( m_vec_header.empty() || !m_vec_header.count( number ) ) return NULL;
     if( number > m_max_res_number || number <= 0 ) return NULL;
 
     return m_vec_header[ number ];

--- a/src/article/layouttree.h
+++ b/src/article/layouttree.h
@@ -7,6 +7,7 @@
 #define _LAYOUTTREE_H
 
 #include <string>
+#include <unordered_map>
 
 #include "jdlib/refptr_lock.h"
 #include "jdlib/heap.h"
@@ -83,7 +84,7 @@ namespace ARTICLE
         JDLIB::HEAP m_heap;
         std::string m_url;
 
-        LAYOUT** m_vec_header;  // ヘッダのポインタの配列
+        std::unordered_map< int, LAYOUT* > m_vec_header;  // ヘッダのポインタの配列
 
         // コメントノードやプレビュー表示時に使うローカルなノードツリー
         DBTREE::NodeTreeBase* m_local_nodetree; 

--- a/src/article/layouttree.h
+++ b/src/article/layouttree.h
@@ -84,7 +84,7 @@ namespace ARTICLE
         JDLIB::HEAP m_heap;
         std::string m_url;
 
-        std::unordered_map< int, LAYOUT* > m_vec_header;  // ヘッダのポインタの配列
+        std::unordered_map< int, LAYOUT* > m_header_map;  // ヘッダのポインタのハッシュマップ
 
         // コメントノードやプレビュー表示時に使うローカルなノードツリー
         DBTREE::NodeTreeBase* m_local_nodetree; 

--- a/src/article/preference.cpp
+++ b/src/article/preference.cpp
@@ -136,7 +136,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
         m_edit_id.set_text( str_id );
         // あぼーんレス番号
         // 連番は 12-34 の様なフォーマットに変換
-        const std::unordered_set< int >& set_res = DBTREE::get_abone_vec_res( get_url() );
+        const std::unordered_set< int >& set_res = DBTREE::get_abone_reses( get_url() );
         // レス番号をソートする
         const std::set< int > tmp_set{ set_res.begin(), set_res.end() };
         int pre_res = 0;

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -160,7 +160,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
     // 最大レス数
     const int max_res = DBTREE::board_get_number_max_res( get_url() );
     m_label_maxres.set_text( "最大レス数 (0 : 未設定)：" );
-    m_spin_maxres.set_range( 0, MAX_RESNUMBER );
+    m_spin_maxres.set_range( 0, kMaxResNumber );
     m_spin_maxres.set_increments( 1, 1 );
     m_spin_maxres.set_value( max_res );
     m_spin_maxres.set_sensitive( true );

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -93,6 +93,10 @@ ArticleBase::ArticleBase( const std::string& datbase, const std::string& id, boo
 //    std::cout << "ArticleBase::ArticleBase : " << m_id << std::endl;
 #endif
 
+    m_vec_abone_res.reserve( kExpectedResInfo );
+    m_vec_bookmark.reserve( kExpectedResInfo );
+    m_vec_posted.reserve( kExpectedResInfo );
+
     memset( &m_access_time, 0, sizeof( struct timeval ) );
     memset( &m_check_update_time, 0, sizeof( struct timeval ) );
     memset( &m_write_time, 0, sizeof( struct timeval ) );
@@ -570,11 +574,7 @@ void ArticleBase::update_writetime()
 //
 int ArticleBase::get_num_posted()
 {
-    if( ! m_vec_posted.size() ) return 0;
-
-    int ret = 0;
-    for( int i = 1; i < MAX_RESNUMBER; ++i ) if( is_posted( i ) ) ++ret;
-    return ret;
+    return m_vec_posted.size();
 }
 
 
@@ -704,11 +704,13 @@ void ArticleBase::reset_abone( const std::list< std::string >& ids,
 
     if( vec_abone_res.size() ){
 
-        if( ! m_vec_abone_res.size() ) m_vec_abone_res.resize( MAX_RESNUMBER );
-
         for( int i = 1; i <= MIN( m_number_load, (int)vec_abone_res.size() ) ; ++i ){
-            if( vec_abone_res[ i ] ) m_vec_abone_res[ i ] = true;
-            else m_vec_abone_res[ i ] = false;
+            if( vec_abone_res[ i ] ) {
+                m_vec_abone_res.insert( i );
+            }
+            else {
+                m_vec_abone_res.erase( i );
+            }
         }
     }
     
@@ -801,9 +803,12 @@ void ArticleBase::set_abone_res( const int num_from, const int num_to, const boo
     std::cout << "ArticleBase::set_abone_res num_from = " << num_from << " num_to = " << num_to << " set = " << set << std::endl;
 #endif    
 
-    if( ! m_vec_abone_res.size() ) m_vec_abone_res.resize( MAX_RESNUMBER );
-
-    for( int i = num_from; i <= num_to; ++i ) m_vec_abone_res[ i ] = set;
+    if( set ) {
+        for( int i = num_from; i <= num_to; ++i ) m_vec_abone_res.insert( i );
+    }
+    else {
+        for( int i = num_from; i <= num_to; ++i ) m_vec_abone_res.erase( i );
+    }
 
     update_abone();
 
@@ -892,11 +897,7 @@ void ArticleBase::set_abone_global( const bool set )
 //
 int ArticleBase::get_num_bookmark()
 {
-    if( ! m_vec_bookmark.size() ) return 0;
-
-    int ret = 0;
-    for( int i = 1; i < MAX_RESNUMBER; ++i ) if( is_bookmarked( i ) ) ++ret;
-    return ret;
+    return m_vec_bookmark.size();
 }
 
 
@@ -908,11 +909,9 @@ bool ArticleBase::is_bookmarked( const int number )
     if( number <= 0 || number > m_number_load ) return false;
 
     // まだnodetreeが作られてなくてブックマークの情報が得られてないのでnodetreeを作って情報取得
-    if( ! m_vec_bookmark.size() ) get_nodetree();
+    if( m_vec_bookmark.empty() ) get_nodetree();
 
-    if( ! m_vec_bookmark.size() ) return false;
-
-    return ( m_vec_bookmark[ number ] );
+    return ( m_vec_bookmark.find( number ) != m_vec_bookmark.end() );
 }
 
 
@@ -921,13 +920,16 @@ bool ArticleBase::is_bookmarked( const int number )
 //
 void ArticleBase::set_bookmark( const int number, const bool set )
 {
-    if( ! m_vec_bookmark.size() ) get_nodetree();
+    if( m_vec_bookmark.empty() ) get_nodetree();
     if( number <= 0 || number > MAX_RESNUMBER ) return;
 
-    if( ! m_vec_bookmark.size() ) m_vec_bookmark.resize( MAX_RESNUMBER );
-
     m_save_info = true;
-    m_vec_bookmark[ number ] = set;
+    if( set ) {
+        m_vec_bookmark.insert( number );
+    }
+    else {
+        m_vec_bookmark.erase( number );
+    }
 }
 
 
@@ -939,11 +941,9 @@ bool ArticleBase::is_posted( const int number )
     if( number <= 0 || number > m_number_load ) return false;
 
     // まだnodetreeが作られてなくて情報が得られてないのでnodetreeを作って情報取得
-    if( ! m_vec_posted.size() ) get_nodetree();
+    if( m_vec_posted.empty() ) get_nodetree();
 
-    if( ! m_vec_posted.size() ) return false;
-
-    return ( m_vec_posted[ number ] );
+    return ( m_vec_posted.find( number ) != m_vec_posted.end() );
 }
 
 
@@ -960,12 +960,15 @@ void ArticleBase::set_posted( const int number, const bool set )
     if( number <= 0 || number > m_number_load ) return;
 
     // まだnodetreeが作られてなくて情報が得られてないのでnodetreeを作って情報取得
-    if( ! m_vec_posted.size() ) get_nodetree();
-
-    if( ! m_vec_posted.size() ) m_vec_posted.resize( MAX_RESNUMBER );
+    if( m_vec_posted.empty() ) get_nodetree();
 
     m_save_info = true;
-    m_vec_posted[ number ] = set;
+    if( set ) {
+        m_vec_posted.insert( number );
+    }
+    else {
+        m_vec_posted.erase( number );
+    }
 
     // nodetreeに情報反映
     m_nodetree->set_posted( number, set );
@@ -979,7 +982,7 @@ void ArticleBase::clear_post_history()
     if( ! is_cached() ) return;
 
     read_info();
-    if( m_vec_posted.size() || m_write_time.tv_sec || m_write_time.tv_usec ){
+    if( !m_vec_posted.empty() || m_write_time.tv_sec || m_write_time.tv_usec ){
 
 #ifdef _DEBUG
         std::cout << "ArticleBase::clear_post_history size = " << m_vec_posted.size()
@@ -1374,17 +1377,21 @@ void ArticleBase::slot_load_finished()
     else m_number_new = 0;
 
     // 書き込み情報
-    if( m_number_new && m_nodetree->get_vec_posted().size() ){
+    const auto& node_posted = m_nodetree->get_vec_posted();
+    if( m_number_new && node_posted.size() ){
 
-        if( ! m_vec_posted.size() ) m_vec_posted.resize( MAX_RESNUMBER );
-
+        const auto end = m_vec_posted.end();
+        const auto node_end = node_posted.end();
         for( int i = m_number_before_load +1; i <= m_number_load; ++i ){
 
-            if( m_nodetree->get_vec_posted()[ i ] ) m_vec_posted[ i ] = true;
-            else m_vec_posted[ i ] = false;
-
+            if( node_posted.find( i ) != node_end ) {
+                m_vec_posted.insert( i );
+            }
+            else {
+                m_vec_posted.erase( i );
+            }
 #ifdef _DEBUG
-            if( m_vec_posted[ i ] ) std::cout << "posted no = " << i << std::endl;
+            if( m_vec_posted.find( i ) != end ) std::cout << "posted no = " << i << std::endl;
 #endif
         }
     }
@@ -1890,14 +1897,14 @@ void ArticleBase::read_info()
         GET_INFOVALUE( str_tmp, "bookmark = " );
         if( ! str_tmp.empty() ){
 
-            if( ! m_vec_bookmark.size() ) m_vec_bookmark.resize( MAX_RESNUMBER );
-
             list_tmp = MISC::split_line( str_tmp );
-            it_tmp = list_tmp.begin();
-            for( ; it_tmp != list_tmp.end(); ++it_tmp ){
-                int number = atoi( (*it_tmp).c_str() );
-                if( !(*it_tmp).empty() ) m_vec_bookmark[ number ] = true;
-                else m_vec_bookmark[ number ] = false;
+            if( m_vec_bookmark.bucket_count() < list_tmp.size() ) {
+                m_vec_bookmark.reserve( list_tmp.size() + kExpectedResInfo );
+            }
+            for( const std::string& num_str : list_tmp ) {
+                if( !num_str.empty() ) {
+                    m_vec_bookmark.insert( std::stoi( num_str ) );
+                }
             }
         }
 
@@ -1924,14 +1931,14 @@ void ArticleBase::read_info()
         GET_INFOVALUE( str_tmp, "aboneres = " );
         if( ! str_tmp.empty() ){
 
-            if( ! m_vec_abone_res.size() ) m_vec_abone_res.resize( MAX_RESNUMBER );
-
             list_tmp = MISC::split_line( str_tmp );
-            it_tmp = list_tmp.begin();
-            for( ; it_tmp != list_tmp.end(); ++it_tmp ){
-                int number = atoi( (*it_tmp).c_str() );
-                if( !(*it_tmp).empty() ) m_vec_abone_res[ number ] = true;
-                else m_vec_abone_res[ number ] = false;
+            if( m_vec_abone_res.bucket_count() < list_tmp.size() ) {
+                m_vec_abone_res.reserve( list_tmp.size() + kExpectedResInfo );
+            }
+            for( const std::string& num_str : list_tmp ) {
+                if( !num_str.empty() ) {
+                    m_vec_abone_res.insert( std::stoi( num_str ) );
+                }
             }
         }
 
@@ -1944,14 +1951,14 @@ void ArticleBase::read_info()
         GET_INFOVALUE( str_tmp, "posted = " );
         if( ! str_tmp.empty() ){
 
-            if( ! m_vec_posted.size() ) m_vec_posted.resize( MAX_RESNUMBER );
-
             list_tmp = MISC::split_line( str_tmp );
-            it_tmp = list_tmp.begin();
-            for( ; it_tmp != list_tmp.end(); ++it_tmp ){
-                int number = atoi( (*it_tmp).c_str() );
-                if( !(*it_tmp).empty() ) m_vec_posted[ number ] = true;
-                else m_vec_posted[ number ] = false;
+            if( m_vec_posted.bucket_count() < list_tmp.size() ) {
+                m_vec_posted.reserve( list_tmp.size() + kExpectedResInfo );
+            }
+            for( const std::string& num_str : list_tmp ) {
+                if( !num_str.empty() ) {
+                    m_vec_posted.insert( std::stoi( num_str ) );
+                }
             }
         }
 
@@ -2052,21 +2059,29 @@ void ArticleBase::read_info()
     std::cout << "abone-regex\n"; it = m_list_abone_regex.begin();
     for( ; it != m_list_abone_regex.end(); ++it ) std::cout << (*it) << std::endl;
 
-    if( m_vec_abone_res.size() ){
+    if( !m_vec_abone_res.empty() ) {
         std::cout << "abone-res =";
-        for( int i = 1; i <= m_number_load; ++i ) if( m_vec_abone_res[ i ] ) std::cout << " " << i;
+        const auto end = m_vec_abone_res.end();
+        for( int i = 1; i <= m_number_load; ++i ) {
+            if( m_vec_abone_res.find( i ) != end ) std::cout << ' ' << i;
+        }
+    }
+
+    if( !m_vec_bookmark.empty() ) {
+        std::cout << "bookmark = ";
+        const auto end = m_vec_bookmark.end();
+        for( int i = 1; i <= m_number_load; ++i ) {
+            if( m_vec_bookmark.find( i ) != end ) std::cout << ' ' << i;
+        }
         std::cout << std::endl;
     }
 
-    if( m_vec_bookmark.size() ){
-        std::cout << "bookmark =";
-        for( int i = 1; i <= m_number_load; ++i ) if( m_vec_bookmark[ i ] ) std::cout << " " << i;
-        std::cout << std::endl;
-    }
-
-    if( m_vec_posted.size() ){
+    if( !m_vec_posted.empty() ) {
         std::cout << "posted =";
-        for( int i = 1; i <= m_number_load; ++i ) if( m_vec_posted[ i ] ) std::cout << " " << i;
+        const auto end = m_vec_posted.end();
+        for( int i = 1; i <= m_number_load; ++i ) {
+            if( m_vec_posted.find( i ) != end ) std::cout << ' ' << i;
+        }
         std::cout << std::endl;
     }
 #endif
@@ -2119,20 +2134,29 @@ void ArticleBase::save_info( const bool force )
 
     // レスあぼーん
     std::ostringstream ss_abone_res;
-    if( m_vec_abone_res.size() ){
-        for( int i = 1; i <= m_number_load; ++i ) if( m_vec_abone_res[ i ] ) ss_abone_res << " " << i;
+    if( !m_vec_abone_res.empty() ) {
+        const auto end = m_vec_abone_res.end();
+        for( int i = 1; i <= m_number_load; ++i ) {
+            if( m_vec_abone_res.find( i ) != end ) ss_abone_res << ' ' << i;
+        }
     }
 
     // レスのブックマーク
     std::ostringstream ss_bookmark;
-    if( m_vec_bookmark.size() ){
-        for( int i = 1; i <= m_number_load; ++i ) if( m_vec_bookmark[ i ] ) ss_bookmark << " " << i;
+    if( !m_vec_bookmark.empty() ) {
+        const auto end = m_vec_bookmark.end();
+        for( int i = 1; i <= m_number_load; ++i ) {
+            if( m_vec_bookmark.find( i ) != end ) ss_bookmark << ' ' << i;
+        }
     }
 
     // 書き込み
     std::ostringstream ss_posted;
-    if( m_vec_posted.size() ){
-        for( int i = 1; i <= m_number_load; ++i ) if( m_vec_posted[ i ] ) ss_posted << " " << i;
+    if( !m_vec_posted.empty() ) {
+        const auto end = m_vec_posted.end();
+        for( int i = 1; i <= m_number_load; ++i ) {
+            if( m_vec_posted.find( i ) != end ) ss_posted << ' ' << i;
+        }
     }
 
     std::ostringstream sstr;

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -797,7 +797,7 @@ void ArticleBase::set_abone_res( const int num_from, const int num_to, const boo
 {
     if( empty() ) return;
     if( num_from > num_to ) return;
-    if( num_from <= 0 || num_to >= MAX_RESNUMBER ) return;
+    if( num_from <= 0 || num_to > kMaxResNumber ) return;
 
 #ifdef _DEBUG
     std::cout << "ArticleBase::set_abone_res num_from = " << num_from << " num_to = " << num_to << " set = " << set << std::endl;
@@ -921,7 +921,7 @@ bool ArticleBase::is_bookmarked( const int number )
 void ArticleBase::set_bookmark( const int number, const bool set )
 {
     if( m_vec_bookmark.empty() ) get_nodetree();
-    if( number <= 0 || number > MAX_RESNUMBER ) return;
+    if( number <= 0 || number > kMaxResNumber ) return;
 
     m_save_info = true;
     if( set ) {

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -93,9 +93,9 @@ ArticleBase::ArticleBase( const std::string& datbase, const std::string& id, boo
 //    std::cout << "ArticleBase::ArticleBase : " << m_id << std::endl;
 #endif
 
-    m_vec_abone_res.reserve( kExpectedResInfo );
-    m_vec_bookmark.reserve( kExpectedResInfo );
-    m_vec_posted.reserve( kExpectedResInfo );
+    m_abone_reses.reserve( kExpectedResInfo );
+    m_bookmarks.reserve( kExpectedResInfo );
+    m_posts.reserve( kExpectedResInfo );
 
     memset( &m_access_time, 0, sizeof( struct timeval ) );
     memset( &m_check_update_time, 0, sizeof( struct timeval ) );
@@ -574,7 +574,7 @@ void ArticleBase::update_writetime()
 //
 int ArticleBase::get_num_posted()
 {
-    return m_vec_posted.size();
+    return m_posts.size();
 }
 
 
@@ -662,7 +662,7 @@ void ArticleBase::update_abone()
     // nodetreeが作られていないときは更新しない
     if( ! m_nodetree ) return;
 
-    get_nodetree()->copy_abone_info( m_list_abone_id, m_list_abone_name, m_list_abone_word, m_list_abone_regex, m_vec_abone_res,
+    get_nodetree()->copy_abone_info( m_list_abone_id, m_list_abone_name, m_list_abone_word, m_list_abone_regex, m_abone_reses,
                                      m_abone_transparent, m_abone_chain, m_abone_age, m_abone_board, m_abone_global );
 
     get_nodetree()->update_abone_all();
@@ -706,10 +706,10 @@ void ArticleBase::reset_abone( const std::list< std::string >& ids,
 
         for( int i = 1; i <= MIN( m_number_load, (int)vec_abone_res.size() ) ; ++i ){
             if( vec_abone_res[ i ] ) {
-                m_vec_abone_res.insert( i );
+                m_abone_reses.insert( i );
             }
             else {
-                m_vec_abone_res.erase( i );
+                m_abone_reses.erase( i );
             }
         }
     }
@@ -804,10 +804,10 @@ void ArticleBase::set_abone_res( const int num_from, const int num_to, const boo
 #endif    
 
     if( set ) {
-        for( int i = num_from; i <= num_to; ++i ) m_vec_abone_res.insert( i );
+        for( int i = num_from; i <= num_to; ++i ) m_abone_reses.insert( i );
     }
     else {
-        for( int i = num_from; i <= num_to; ++i ) m_vec_abone_res.erase( i );
+        for( int i = num_from; i <= num_to; ++i ) m_abone_reses.erase( i );
     }
 
     update_abone();
@@ -897,7 +897,7 @@ void ArticleBase::set_abone_global( const bool set )
 //
 int ArticleBase::get_num_bookmark()
 {
-    return m_vec_bookmark.size();
+    return m_bookmarks.size();
 }
 
 
@@ -909,9 +909,9 @@ bool ArticleBase::is_bookmarked( const int number )
     if( number <= 0 || number > m_number_load ) return false;
 
     // まだnodetreeが作られてなくてブックマークの情報が得られてないのでnodetreeを作って情報取得
-    if( m_vec_bookmark.empty() ) get_nodetree();
+    if( m_bookmarks.empty() ) get_nodetree();
 
-    return ( m_vec_bookmark.find( number ) != m_vec_bookmark.end() );
+    return ( m_bookmarks.find( number ) != m_bookmarks.end() );
 }
 
 
@@ -920,15 +920,15 @@ bool ArticleBase::is_bookmarked( const int number )
 //
 void ArticleBase::set_bookmark( const int number, const bool set )
 {
-    if( m_vec_bookmark.empty() ) get_nodetree();
+    if( m_bookmarks.empty() ) get_nodetree();
     if( number <= 0 || number > kMaxResNumber ) return;
 
     m_save_info = true;
     if( set ) {
-        m_vec_bookmark.insert( number );
+        m_bookmarks.insert( number );
     }
     else {
-        m_vec_bookmark.erase( number );
+        m_bookmarks.erase( number );
     }
 }
 
@@ -941,9 +941,9 @@ bool ArticleBase::is_posted( const int number )
     if( number <= 0 || number > m_number_load ) return false;
 
     // まだnodetreeが作られてなくて情報が得られてないのでnodetreeを作って情報取得
-    if( m_vec_posted.empty() ) get_nodetree();
+    if( m_posts.empty() ) get_nodetree();
 
-    return ( m_vec_posted.find( number ) != m_vec_posted.end() );
+    return ( m_posts.find( number ) != m_posts.end() );
 }
 
 
@@ -960,14 +960,14 @@ void ArticleBase::set_posted( const int number, const bool set )
     if( number <= 0 || number > m_number_load ) return;
 
     // まだnodetreeが作られてなくて情報が得られてないのでnodetreeを作って情報取得
-    if( m_vec_posted.empty() ) get_nodetree();
+    if( m_posts.empty() ) get_nodetree();
 
     m_save_info = true;
     if( set ) {
-        m_vec_posted.insert( number );
+        m_posts.insert( number );
     }
     else {
-        m_vec_posted.erase( number );
+        m_posts.erase( number );
     }
 
     // nodetreeに情報反映
@@ -982,14 +982,14 @@ void ArticleBase::clear_post_history()
     if( ! is_cached() ) return;
 
     read_info();
-    if( !m_vec_posted.empty() || m_write_time.tv_sec || m_write_time.tv_usec ){
+    if( !m_posts.empty() || m_write_time.tv_sec || m_write_time.tv_usec ){
 
 #ifdef _DEBUG
-        std::cout << "ArticleBase::clear_post_history size = " << m_vec_posted.size()
+        std::cout << "ArticleBase::clear_post_history size = " << m_posts.size()
                   << " time = " << m_write_time_date
                   << " subject = " << m_subject << std::endl;
 #endif
-        m_vec_posted.clear();
+        m_posts.clear();
         memset( &m_write_time, 0, sizeof( struct timeval ) );
         m_write_time_date = std::string();
 
@@ -1027,11 +1027,11 @@ JDLIB::ConstPtr< NodeTreeBase >& ArticleBase::get_nodetree()
         assert( m_nodetree );
 
         // あぼーん情報のコピー
-        m_nodetree->copy_abone_info( m_list_abone_id, m_list_abone_name, m_list_abone_word, m_list_abone_regex, m_vec_abone_res,
+        m_nodetree->copy_abone_info( m_list_abone_id, m_list_abone_name, m_list_abone_word, m_list_abone_regex, m_abone_reses,
                                      m_abone_transparent, m_abone_chain, m_abone_age, m_abone_board, m_abone_global );
 
         // 書き込み情報のコピー
-        m_nodetree->copy_post_info( m_vec_posted );
+        m_nodetree->copy_post_info( m_posts );
 
         m_nodetree->sig_updated().connect( sigc::mem_fun( *this, &ArticleBase::slot_node_updated ) );
         m_nodetree->sig_finished().connect( sigc::mem_fun( *this, &ArticleBase::slot_load_finished ) );
@@ -1377,21 +1377,21 @@ void ArticleBase::slot_load_finished()
     else m_number_new = 0;
 
     // 書き込み情報
-    const auto& node_posted = m_nodetree->get_vec_posted();
-    if( m_number_new && node_posted.size() ){
+    const auto& node_posts = m_nodetree->get_posts();
+    if( m_number_new && node_posts.size() ) {
 
-        const auto end = m_vec_posted.end();
-        const auto node_end = node_posted.end();
+        const auto end = m_posts.end();
+        const auto node_end = node_posts.end();
         for( int i = m_number_before_load +1; i <= m_number_load; ++i ){
 
-            if( node_posted.find( i ) != node_end ) {
-                m_vec_posted.insert( i );
+            if( node_posts.find( i ) != node_end ) {
+                m_posts.insert( i );
             }
             else {
-                m_vec_posted.erase( i );
+                m_posts.erase( i );
             }
 #ifdef _DEBUG
-            if( m_vec_posted.find( i ) != end ) std::cout << "posted no = " << i << std::endl;
+            if( m_posts.find( i ) != end ) std::cout << "posted no = " << i << std::endl;
 #endif
         }
     }
@@ -1718,13 +1718,13 @@ void ArticleBase::delete_cache( const bool cache_only )
         m_write_fixname = false;
         m_write_fixmail = false;
 
-        m_vec_bookmark.clear();
-        m_vec_posted.clear();
+        m_bookmarks.clear();
+        m_posts.clear();
         m_list_abone_id.clear();
         m_list_abone_name.clear();
         m_list_abone_word.clear();
         m_list_abone_regex.clear();
-        m_vec_abone_res.clear();
+        m_abone_reses.clear();
         m_abone_transparent = false;
         m_abone_chain = false;
         m_abone_age = false;
@@ -1898,12 +1898,12 @@ void ArticleBase::read_info()
         if( ! str_tmp.empty() ){
 
             list_tmp = MISC::split_line( str_tmp );
-            if( m_vec_bookmark.bucket_count() < list_tmp.size() ) {
-                m_vec_bookmark.reserve( list_tmp.size() + kExpectedResInfo );
+            if( m_bookmarks.bucket_count() < list_tmp.size() ) {
+                m_bookmarks.reserve( list_tmp.size() + kExpectedResInfo );
             }
             for( const std::string& num_str : list_tmp ) {
                 if( !num_str.empty() ) {
-                    m_vec_bookmark.insert( std::stoi( num_str ) );
+                    m_bookmarks.insert( std::stoi( num_str ) );
                 }
             }
         }
@@ -1927,17 +1927,17 @@ void ArticleBase::read_info()
         if( ! str_tmp.empty() ) m_abone_chain = atoi( str_tmp.c_str() );
 
         // レス番号あぼーん
-        m_vec_abone_res.clear();
+        m_abone_reses.clear();
         GET_INFOVALUE( str_tmp, "aboneres = " );
         if( ! str_tmp.empty() ){
 
             list_tmp = MISC::split_line( str_tmp );
-            if( m_vec_abone_res.bucket_count() < list_tmp.size() ) {
-                m_vec_abone_res.reserve( list_tmp.size() + kExpectedResInfo );
+            if( m_abone_reses.bucket_count() < list_tmp.size() ) {
+                m_abone_reses.reserve( list_tmp.size() + kExpectedResInfo );
             }
             for( const std::string& num_str : list_tmp ) {
                 if( !num_str.empty() ) {
-                    m_vec_abone_res.insert( std::stoi( num_str ) );
+                    m_abone_reses.insert( std::stoi( num_str ) );
                 }
             }
         }
@@ -1952,12 +1952,12 @@ void ArticleBase::read_info()
         if( ! str_tmp.empty() ){
 
             list_tmp = MISC::split_line( str_tmp );
-            if( m_vec_posted.bucket_count() < list_tmp.size() ) {
-                m_vec_posted.reserve( list_tmp.size() + kExpectedResInfo );
+            if( m_posts.bucket_count() < list_tmp.size() ) {
+                m_posts.reserve( list_tmp.size() + kExpectedResInfo );
             }
             for( const std::string& num_str : list_tmp ) {
                 if( !num_str.empty() ) {
-                    m_vec_posted.insert( std::stoi( num_str ) );
+                    m_posts.insert( std::stoi( num_str ) );
                 }
             }
         }
@@ -2059,28 +2059,28 @@ void ArticleBase::read_info()
     std::cout << "abone-regex\n"; it = m_list_abone_regex.begin();
     for( ; it != m_list_abone_regex.end(); ++it ) std::cout << (*it) << std::endl;
 
-    if( !m_vec_abone_res.empty() ) {
+    if( !m_abone_reses.empty() ) {
         std::cout << "abone-res =";
-        const auto end = m_vec_abone_res.end();
+        const auto end = m_abone_reses.end();
         for( int i = 1; i <= m_number_load; ++i ) {
-            if( m_vec_abone_res.find( i ) != end ) std::cout << ' ' << i;
+            if( m_abone_reses.find( i ) != end ) std::cout << ' ' << i;
         }
     }
 
-    if( !m_vec_bookmark.empty() ) {
+    if( !m_bookmarks.empty() ) {
         std::cout << "bookmark = ";
-        const auto end = m_vec_bookmark.end();
+        const auto end = m_bookmarks.end();
         for( int i = 1; i <= m_number_load; ++i ) {
-            if( m_vec_bookmark.find( i ) != end ) std::cout << ' ' << i;
+            if( m_bookmarks.find( i ) != end ) std::cout << ' ' << i;
         }
         std::cout << std::endl;
     }
 
-    if( !m_vec_posted.empty() ) {
+    if( !m_posts.empty() ) {
         std::cout << "posted =";
-        const auto end = m_vec_posted.end();
+        const auto end = m_posts.end();
         for( int i = 1; i <= m_number_load; ++i ) {
-            if( m_vec_posted.find( i ) != end ) std::cout << ' ' << i;
+            if( m_posts.find( i ) != end ) std::cout << ' ' << i;
         }
         std::cout << std::endl;
     }
@@ -2134,28 +2134,28 @@ void ArticleBase::save_info( const bool force )
 
     // レスあぼーん
     std::ostringstream ss_abone_res;
-    if( !m_vec_abone_res.empty() ) {
-        const auto end = m_vec_abone_res.end();
+    if( !m_abone_reses.empty() ) {
+        const auto end = m_abone_reses.end();
         for( int i = 1; i <= m_number_load; ++i ) {
-            if( m_vec_abone_res.find( i ) != end ) ss_abone_res << ' ' << i;
+            if( m_abone_reses.find( i ) != end ) ss_abone_res << ' ' << i;
         }
     }
 
     // レスのブックマーク
     std::ostringstream ss_bookmark;
-    if( !m_vec_bookmark.empty() ) {
-        const auto end = m_vec_bookmark.end();
+    if( !m_bookmarks.empty() ) {
+        const auto end = m_bookmarks.end();
         for( int i = 1; i <= m_number_load; ++i ) {
-            if( m_vec_bookmark.find( i ) != end ) ss_bookmark << ' ' << i;
+            if( m_bookmarks.find( i ) != end ) ss_bookmark << ' ' << i;
         }
     }
 
     // 書き込み
     std::ostringstream ss_posted;
-    if( !m_vec_posted.empty() ) {
-        const auto end = m_vec_posted.end();
+    if( !m_posts.empty() ) {
+        const auto end = m_posts.end();
         for( int i = 1; i <= m_number_load; ++i ) {
-            if( m_vec_posted.find( i ) != end ) ss_posted << ' ' << i;
+            if( m_posts.find( i ) != end ) ss_posted << ' ' << i;
         }
     }
 

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -19,6 +19,8 @@
 
 #include "jdlib/constptr.h"
 
+#include <unordered_set>
+
 namespace DBTREE
 {
     class NodeTreeBase;
@@ -74,7 +76,7 @@ namespace DBTREE
         std::list< std::string > m_list_abone_name; // あぼーんする名前
         std::list< std::string > m_list_abone_word; // あぼーんする文字列
         std::list< std::string > m_list_abone_regex; // あぼーんする正規表現
-        std::vector< char > m_vec_abone_res; // レスあぼーん情報
+        std::unordered_set< int > m_vec_abone_res; // レスあぼーん情報
         bool m_abone_transparent; // 透明あぼーん
         bool m_abone_chain; // 連鎖あぼーん
         bool m_abone_age; // age ているレスをあぼーん
@@ -85,10 +87,10 @@ namespace DBTREE
         bool m_bookmarked_thread;
 
         // 「レス」のブックマーク
-        std::vector< char > m_vec_bookmark; // ブックマーク判定キャッシュ
+        std::unordered_set< int > m_vec_bookmark; // ブックマーク判定キャッシュ
 
         // 自分が書き込んだレスか
-        std::vector< char > m_vec_posted;
+        std::unordered_set< int > m_vec_posted;
 
         // HDDにキャッシュされているか
         bool m_cached;
@@ -317,7 +319,7 @@ namespace DBTREE
         const std::list< std::string >& get_abone_list_name(){ return m_list_abone_name; }
         const std::list< std::string >& get_abone_list_word(){ return m_list_abone_word; }
         const std::list< std::string >& get_abone_list_regex(){ return m_list_abone_regex; }
-        const std::vector< char >& get_abone_vec_res(){ return m_vec_abone_res; }
+        const std::unordered_set< int >& get_abone_vec_res() const noexcept { return m_vec_abone_res; }
 
         // 透明
         bool get_abone_transparent();

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -76,7 +76,7 @@ namespace DBTREE
         std::list< std::string > m_list_abone_name; // あぼーんする名前
         std::list< std::string > m_list_abone_word; // あぼーんする文字列
         std::list< std::string > m_list_abone_regex; // あぼーんする正規表現
-        std::unordered_set< int > m_vec_abone_res; // レスあぼーん情報
+        std::unordered_set< int > m_abone_reses; // レスあぼーん情報
         bool m_abone_transparent; // 透明あぼーん
         bool m_abone_chain; // 連鎖あぼーん
         bool m_abone_age; // age ているレスをあぼーん
@@ -87,10 +87,10 @@ namespace DBTREE
         bool m_bookmarked_thread;
 
         // 「レス」のブックマーク
-        std::unordered_set< int > m_vec_bookmark; // ブックマーク判定キャッシュ
+        std::unordered_set< int > m_bookmarks; // ブックマーク判定キャッシュ
 
         // 自分が書き込んだレスか
-        std::unordered_set< int > m_vec_posted;
+        std::unordered_set< int > m_posts;
 
         // HDDにキャッシュされているか
         bool m_cached;
@@ -319,7 +319,7 @@ namespace DBTREE
         const std::list< std::string >& get_abone_list_name(){ return m_list_abone_name; }
         const std::list< std::string >& get_abone_list_word(){ return m_list_abone_word; }
         const std::list< std::string >& get_abone_list_regex(){ return m_list_abone_regex; }
-        const std::unordered_set< int >& get_abone_vec_res() const noexcept { return m_vec_abone_res; }
+        const std::unordered_set< int >& get_abone_reses() const noexcept { return m_abone_reses; }
 
         // 透明
         bool get_abone_transparent();

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -494,7 +494,7 @@ void BoardBase::set_number_max_res( const int number )
     std::cout << "BoardBase::set_number_max_res " << m_number_max_res << " -> " << number << std::endl;
 #endif
 
-    m_number_max_res = MAX( 0, MIN( MAX_RESNUMBER, number ) );
+    m_number_max_res = MAX( 0, MIN( kMaxResNumber, number ) );
 
     ArticleHashIterator it = m_hash_article->begin();
     for( ; it != m_hash_article->end(); ++it ) ( *it )->set_number_max( m_number_max_res );
@@ -631,7 +631,7 @@ std::string BoardBase::url_dat( const std::string& url, int& num_from, int& num_
             num_from = MAX( 1, num_from );
 
             // 12- みたいな場合はとりあえず大きい数字を入れとく
-            if( !regex.str( 5 ).empty() && !num_to ) num_to = MAX_RESNUMBER + 1;
+            if( !regex.str( 5 ).empty() && !num_to ) num_to = kMaxResNumber + 1;
         }
 
         // -15 みたいな場合
@@ -2088,7 +2088,7 @@ void BoardBase::read_board_info()
     m_status = cf.get_option_int( "status", STATUS_UNKNOWN, 0, 8192 );
 
     // 最大レス数
-    m_number_max_res = cf.get_option_int( "max_res", get_default_number_max_res(), 0, MAX_RESNUMBER );
+    m_number_max_res = cf.get_option_int( "max_res", get_default_number_max_res(), 0, kMaxResNumber );
 
 #ifdef _DEBUG
     std::cout << "modified = " << get_date_modified() << std::endl;

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -1169,9 +1169,9 @@ const std::list< std::string >& DBTREE::get_abone_list_regex( const std::string&
 }
 
 
-const std::unordered_set< int >& DBTREE::get_abone_vec_res( const std::string& url )
+const std::unordered_set< int >& DBTREE::get_abone_reses( const std::string& url )
 {
-    return DBTREE::get_article( url )->get_abone_vec_res();
+    return DBTREE::get_article( url )->get_abone_reses();
 }
 
 

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -1169,7 +1169,7 @@ const std::list< std::string >& DBTREE::get_abone_list_regex( const std::string&
 }
 
 
-const std::vector< char >& DBTREE::get_abone_vec_res( const std::string& url )
+const std::unordered_set< int >& DBTREE::get_abone_vec_res( const std::string& url )
 {
     return DBTREE::get_article( url )->get_abone_vec_res();
 }

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -327,7 +327,7 @@ namespace DBTREE
     const std::list< std::string >& get_abone_list_thread_remove( const std::string& url );
     const std::list< std::string >& get_abone_list_word_thread( const std::string& url );
     const std::list< std::string >& get_abone_list_regex_thread( const std::string& url );
-    const std::unordered_set< int >& get_abone_vec_res( const std::string& url );
+    const std::unordered_set< int >& get_abone_reses( const std::string& url );
     int get_abone_number_thread( const std::string& url );
     int get_abone_hour_thread( const std::string& url );
 

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -13,6 +13,7 @@
 #include <list>
 #include <vector>
 #include <ctime>
+#include <unordered_set>
 
 
 namespace XML
@@ -326,7 +327,7 @@ namespace DBTREE
     const std::list< std::string >& get_abone_list_thread_remove( const std::string& url );
     const std::list< std::string >& get_abone_list_word_thread( const std::string& url );
     const std::list< std::string >& get_abone_list_regex_thread( const std::string& url );
-    const std::vector< char >& get_abone_vec_res( const std::string& url );
+    const std::unordered_set< int >& get_abone_vec_res( const std::string& url );
     int get_abone_number_thread( const std::string& url );
     int get_abone_hour_thread( const std::string& url );
 

--- a/src/dbtree/node.h
+++ b/src/dbtree/node.h
@@ -79,7 +79,6 @@ namespace DBTREE
         bool sage; // メール欄がsageか
 
         int num_id_name; // 同じIDのレスの個数( = 発言数 )
-        NODE* pre_id_name_header; // 同じIDを持つ一つ前のヘッダノードのアドレス
 
         NODE* block[ BLOCK_NUM ];
     };

--- a/src/dbtree/node.h
+++ b/src/dbtree/node.h
@@ -112,7 +112,7 @@ namespace DBTREE
     {
         unsigned char type;
 
-        short id_header; // ヘッダID ( つまりレス番号、ルートヘッダは0 )
+        int id_header; // ヘッダID ( つまりレス番号、ルートヘッダは0 )
         NODE* next_node; // 最終ノードはNULL
         
         char* text;

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -47,7 +47,7 @@ constexpr int LNG_ID = 256;
 constexpr size_t LNG_LINK = 256;
 constexpr size_t MAX_ANCINFO = 64;
 constexpr int RANGE_REF = 20;
-constexpr size_t MAX_LINK_DIGIT = 4;  // レスアンカーでMAX_LINK_DIGIT 桁までリンクにする
+constexpr size_t MAX_LINK_DIGIT = 7;  // レスアンカーでMAX_LINK_DIGIT 桁までリンクにする
 
 constexpr size_t MAXSISE_OF_LINES = 512 * 1024;  // ロード時に１回の呼び出しで読み込まれる最大データサイズ
 constexpr size_t SIZE_OF_HEAP = MAXSISE_OF_LINES + 64;
@@ -96,15 +96,16 @@ NodeTreeBase::NodeTreeBase( const std::string& url, const std::string& modified 
     set_date_modified( modified );
 
     clear();
-    m_vec_header.reserve( MAX_RESNUMBER ) ;
+    m_vec_header.reserve( kExpectedResNumber ) ;
     m_vec_posted.reserve( kExpectedResInfo );
     m_vec_refer_posted.reserve( kExpectedResInfo );
 
     // ルートヘッダ作成。中は空。
     m_id_header = -1; // ルートヘッダIDが 0 になるように -1
     NODE* tmpnode = create_node_header();
-    assert( m_id_header == m_vec_header.size() );
+    assert( static_cast< size_t >( m_id_header ) == m_vec_header.size() );
     m_vec_header.push_back( tmpnode );
+    assert( static_cast< size_t >( kMaxResNumber ) >= m_vec_header.size() );
 
     m_default_noname = DBTREE::default_noname( m_url );
 
@@ -1069,8 +1070,9 @@ NODE* NodeTreeBase::append_html( const std::string& html )
 #endif
 
     NODE* header = create_node_header();
-    assert( m_id_header == m_vec_header.size() );
+    assert( static_cast< size_t >( m_id_header ) == m_vec_header.size() );
     m_vec_header.push_back( header ) ;
+    assert( static_cast< size_t >( kMaxResNumber ) >= m_vec_header.size() );
 
     init_loading();
     header->headinfo->block[ BLOCK_MES ] = create_node_block();
@@ -1557,8 +1559,9 @@ const char* NodeTreeBase::add_one_dat_line( const char* datline )
 
     size_t i;
     NODE* header = create_node_header();
-    assert( m_id_header == m_vec_header.size() );
+    assert( static_cast< size_t >( m_id_header ) == m_vec_header.size() );
     m_vec_header.push_back( header ) ;
+    assert( static_cast< size_t >( kMaxResNumber ) >= m_vec_header.size() );
 
     // レス番号
     char tmplink[ LNG_RES ], tmpstr[ LNG_RES ];
@@ -3261,7 +3264,7 @@ void NodeTreeBase::check_reference( const int number )
 
     // 2重チェック防止用
     std::unordered_set< int > checked;
-    checked.reserve( MAX_RESNUMBER );
+    checked.reserve( kExpectedResNumber );
 
     const bool posted = !m_vec_posted.empty();
 
@@ -3323,7 +3326,7 @@ void NodeTreeBase::check_reference( const int number )
                         if( anc_from == 0 ) break;
                         ++anc;
 
-                        anc_to = MIN( anc_to, MAX_RESNUMBER );
+                        anc_to = MIN( anc_to, kMaxResNumber );
 
                         // >>1-1000 みたいなアンカーは弾く
                         if( anc_to - anc_from >= RANGE_REF ) continue;

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -65,7 +65,7 @@ namespace DBTREE
         bool m_broken;  
 
         JDLIB::HEAP m_heap;
-        NODE** m_vec_header;  // レスのヘッダのポインタの配列
+        std::vector< NODE* > m_vec_header;  // レスのヘッダのポインタの配列
         
         std::string m_subject;
 

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -16,6 +16,7 @@
 
 #include <map>
 #include <cstring>
+#include <unordered_set>
 
 namespace JDLIB
 {
@@ -89,7 +90,7 @@ namespace DBTREE
 
         std::list< std::string > m_list_abone_word_global; // あぼーんする文字列(全体)
         std::list< std::string > m_list_abone_regex_global; // あぼーんする正規表現(全体)
-        std::vector< char > m_vec_abone_res; // レスあぼーん情報
+        std::unordered_set< int > m_vec_abone_res; // レスあぼーん情報
         bool m_abone_transparent; // 透明あぼーん
         bool m_abone_chain; // 連鎖あぼーん
         bool m_abone_age; // age ているレスはあぼーん
@@ -97,10 +98,10 @@ namespace DBTREE
         bool m_abone_global; // 全体レベルでのあぼーんを有効にする
 
         // 自分が書き込んだレスか
-        std::vector< char > m_vec_posted;
+        std::unordered_set< int > m_vec_posted;
 
         // 自分の書き込みにレスしているか
-        std::vector< char > m_vec_refer_posted;
+        std::unordered_set< int > m_vec_refer_posted;
 
         // 未来のレスに対するアンカーがある時に使用する
         // check_reference() を参照
@@ -236,7 +237,7 @@ namespace DBTREE
                               const std::list< std::string >& list_abone_name,
                               const std::list< std::string >& list_abone_word,
                               const std::list< std::string >& list_abone_regex,
-                              const std::vector< char >& vec_abone_res,
+                              const std::unordered_set< int >& vec_abone_res,
                               const bool abone_transparent, const bool abone_chain, const bool abone_age,
                               const bool abone_board, const bool abone_global );
 
@@ -245,8 +246,8 @@ namespace DBTREE
         void update_abone_all();
 
         // 自分が書き込んだレスか
-        void copy_post_info( const std::vector< char >& vec_posted ){ m_vec_posted = vec_posted; }
-        const std::vector< char >& get_vec_posted(){ return m_vec_posted; }
+        void copy_post_info( const std::unordered_set< int >& vec_posted ){ m_vec_posted = vec_posted; }
+        const std::unordered_set< int >& get_vec_posted() const noexcept { return m_vec_posted; }
 
         // 自分の書き込みにレスしたか
         bool is_refer_posted( const int number );

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -369,7 +369,7 @@ namespace DBTREE
 
         // 発言数( num_id_name )の更新
         // IDノードの色も変更する
-        void set_num_id_name( NODE* header, const int num_id_name, NODE* pre_id_name_header );
+        void set_num_id_name( NODE* header, const int num_id_name );
 
 
         // from_number番から to_number 番までのレスのフォント判定を更新

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -90,7 +90,7 @@ namespace DBTREE
 
         std::list< std::string > m_list_abone_word_global; // あぼーんする文字列(全体)
         std::list< std::string > m_list_abone_regex_global; // あぼーんする正規表現(全体)
-        std::unordered_set< int > m_vec_abone_res; // レスあぼーん情報
+        std::unordered_set< int > m_abone_reses; // レスあぼーん情報
         bool m_abone_transparent; // 透明あぼーん
         bool m_abone_chain; // 連鎖あぼーん
         bool m_abone_age; // age ているレスはあぼーん
@@ -98,10 +98,10 @@ namespace DBTREE
         bool m_abone_global; // 全体レベルでのあぼーんを有効にする
 
         // 自分が書き込んだレスか
-        std::unordered_set< int > m_vec_posted;
+        std::unordered_set< int > m_posts;
 
         // 自分の書き込みにレスしているか
-        std::unordered_set< int > m_vec_refer_posted;
+        std::unordered_set< int > m_refer_posts;
 
         // 未来のレスに対するアンカーがある時に使用する
         // check_reference() を参照
@@ -237,7 +237,7 @@ namespace DBTREE
                               const std::list< std::string >& list_abone_name,
                               const std::list< std::string >& list_abone_word,
                               const std::list< std::string >& list_abone_regex,
-                              const std::unordered_set< int >& vec_abone_res,
+                              const std::unordered_set< int >& abone_reses,
                               const bool abone_transparent, const bool abone_chain, const bool abone_age,
                               const bool abone_board, const bool abone_global );
 
@@ -246,8 +246,8 @@ namespace DBTREE
         void update_abone_all();
 
         // 自分が書き込んだレスか
-        void copy_post_info( const std::unordered_set< int >& vec_posted ){ m_vec_posted = vec_posted; }
-        const std::unordered_set< int >& get_vec_posted() const noexcept { return m_vec_posted; }
+        void copy_post_info( const std::unordered_set< int >& posts ){ m_posts = posts; }
+        const std::unordered_set< int >& get_posts() const noexcept { return m_posts; }
 
         // 自分の書き込みにレスしたか
         bool is_refer_posted( const int number );

--- a/src/global.h
+++ b/src/global.h
@@ -18,6 +18,8 @@ enum{
     ICON_SIZE = 32 // 画像アイコンの大きさ
 };
 
+constexpr int kExpectedResInfo{ 512 }; // しおり、書き込み、返信などレス情報の想定値(上限ではない)
+
 
 // 書き込みビューの名前欄の空白
 #define JD_NAME_BLANK "jd_name_blank"

--- a/src/global.h
+++ b/src/global.h
@@ -11,14 +11,15 @@ enum{
     TIMER_TIMEOUT = 50, // msec  内部クロックの周期
     TIMER_TIMEOUT_SMOOTH_SCROLL = 33, // msec  スレビューのスムーススクロール描画用クロック周期
 
-    MAX_RESNUMBER = 11000, // 最大表示可能レス数
-
     MAX_MG_LNG = 5,  // マウスジェスチャの最大ストローク
 
     ICON_SIZE = 32 // 画像アイコンの大きさ
 };
 
+// NOTE: sizeof(int) >= 4を保証するためuniform initializationを使う
 constexpr int kExpectedResInfo{ 512 }; // しおり、書き込み、返信などレス情報の想定値(上限ではない)
+constexpr int kExpectedResNumber{ 11000 }; // 最大レス数の想定値(上限ではない)
+constexpr int kMaxResNumber{ 1048576 }; // 設定可能な最大レス数(2の20乗)
 
 
 // 書き込みビューの名前欄の空白


### PR DESCRIPTION
@taro-yamada 氏の[長大なスレッド(>11000レス?)を開くと落ちる不具合を修正する](https://github.com/JDimproved/JDim/projects/1#card-18008854)の修正v1( https://github.com/taro-yamada/JDim/tree/41306cfb )に２つの変更を追加します。

* しおりなどレス情報を保持するコンテナ型を変更する
* レス数の上限を1048576へ引き上げる

### 変更の内容 (コミットメッセージ)

#### [WIP] Use std::unordered_set instead of std::vector for res information 
レス数の上限を取り除くため`std::vector<char>`で管理しているしおりなどのレス情報をレス番号(int)をキーにした`std::unordered_set<int>`で管理します。`unordered_set`は初期化の際に`kExpectedResInfo`(=512)のサイズに予約します。

##### 修正の根拠
しおり、書き込み、返信などのマークはレス数に対して十分少なくなるはずです。したがって`std::vector`でレス数と同じサイズの領域を確保する必要性は低いと考えられます。

##### パフォーマンスの影響
挿入時にハッシュ計算(レス番号=int)のコストがかかります。また、最悪の場合ハッシュの再計算やメモリの再確保が発生します(`kExpectedResInfo`で調整可能)。レス番号の順序が必要な箇所がありますが実行される条件は限られているので`std::set<int>`の一時変数を使っています。


#### [WIP] Eliminate MAX_RESNUMBER

`MAX_RESNUMBER`を取り除いてレス数の上限を1048576(2の20乗)に引き上げます。
合わせて7桁までのレスアンカーを有効にします。
また、レス番号を表現する符号付き整数は`sizeof(int) >= 4`以上を要件とします。

##### 新たに導入する定数
* `kMaxResNumber` は設定可能な最大レス数(=1048576) : 設定の上限に使われる
* `kExptectedResNumber` は最大レス数の想定値(=11000) : メモリ確保に使われる
