### PR TITLE
[IDEA] JDimproved#230 keep blocks version

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -926,7 +926,14 @@ bool DrawAreaBase::exec_layout_impl( const bool is_popup, const int offset_y )
 
     // 新着セパレータの挿入
     // 実況時は新着セパレータを表示しない(スクロールがガタガタするから)
-    if( ! m_scrollinfo.live ) m_layout_tree->move_separator();
+    // 新着返信は、とにかく一度隠す（layoutの木を正すため）
+    m_layout_tree->hide_layout_refer_posts_from_newres();
+    if( ! m_scrollinfo.live )
+    {
+        m_layout_tree->move_separator();
+        m_layout_tree->create_layout_refer_posts_from_newres();
+        m_layout_tree->insert_layout_refer_posts_from_newres();
+    }
 
     m_width_client = 0;
     m_height_client = 0;

--- a/src/article/layouttree.cpp
+++ b/src/article/layouttree.cpp
@@ -20,7 +20,7 @@
 
 enum
 {
-    SIZE_OF_HEAP = 256 * 1024,
+    SIZE_OF_HEAP_DEFAULT = 256 * 1024,
 
     STEP_ID = 10,
     STEP_SEPARATOR = 1,
@@ -53,7 +53,7 @@ using namespace ARTICLE;
 // show_abone : true ならあぼーんしたレスも表示する
 // show_multispace : true なら連続空白ノードも表示
 LayoutTree::LayoutTree( const std::string& url, const bool show_abone, const bool show_multispace )
-    : m_heap( SIZE_OF_HEAP ),
+    : m_heap_default( SIZE_OF_HEAP_DEFAULT ),
       m_url( url ),
       m_local_nodetree( nullptr ),
       m_separator_header( nullptr ),
@@ -65,6 +65,7 @@ LayoutTree::LayoutTree( const std::string& url, const bool show_abone, const boo
     std::cout << "LayoutTree::LayoutTree : url = " << url << " show_abone = " << m_show_abone << std::endl;
 #endif    
 
+    m_heap = &m_heap_default;
     m_article = DBTREE::get_article( m_url );
     assert( m_article );
 
@@ -85,7 +86,7 @@ LayoutTree::~LayoutTree()
 
 void LayoutTree::clear()
 {
-    m_heap.clear();
+    m_heap_default.clear();
 
     m_map_header.clear();
     
@@ -110,7 +111,7 @@ void LayoutTree::clear()
 // RECTANGLE型のメモリ確保
 RECTANGLE* LayoutTree::create_rect()
 {
-    RECTANGLE* rect = m_heap.heap_alloc<RECTANGLE>();
+    RECTANGLE* rect = m_heap->heap_alloc<RECTANGLE>();
     rect->end = true;
 
     return rect;
@@ -122,7 +123,7 @@ RECTANGLE* LayoutTree::create_rect()
 //
 LAYOUT* LayoutTree::create_layout( const int type )
 {
-    LAYOUT* tmplayout = m_heap.heap_alloc<LAYOUT>();
+    LAYOUT* tmplayout = m_heap->heap_alloc<LAYOUT>();
     tmplayout->type = type;
     tmplayout->id_header = m_id_header; 
     tmplayout->id = m_id_layout++;
@@ -250,7 +251,7 @@ LAYOUT* LayoutTree::create_layout_div( const int id )
 
     m_last_div = div;
 
-    div->css = m_heap.heap_alloc<CORE::CSS_PROPERTY>();
+    div->css = m_heap->heap_alloc<CORE::CSS_PROPERTY>();
     *div->css = CORE::get_css_manager()->get_property( id );
 
     return div;
@@ -575,7 +576,7 @@ LAYOUT* LayoutTree::create_separator()
     LAYOUT* header = create_layout_div( classid );
     header->type = DBTREE::NODE_HEADER;
 
-    DBTREE::NODE* node = m_heap.heap_alloc<DBTREE::NODE>();
+    DBTREE::NODE* node = m_heap->heap_alloc<DBTREE::NODE>();
     node->fontid = FONT_DEFAULT; // デフォルトフォントを設定
     header->node = node;
 

--- a/src/article/layouttree.cpp
+++ b/src/article/layouttree.cpp
@@ -90,7 +90,7 @@ LayoutTree::~LayoutTree()
 
 void LayoutTree::clear()
 {
-    m_heap_default.clear();
+    m_heap_default.clear_while_keeping_blocks();
 
     m_map_header.clear();
     
@@ -783,7 +783,7 @@ void LayoutTree::hide_layout_refer_posts_from_newres()
     // 内部 heap 清掃
     if ( m_local_nodetree_newres ) m_local_nodetree_newres->~NodeTreeBase();
     m_local_nodetree_newres = nullptr;
-    m_heap_refer_posts_from_newres.clear();
+    m_heap_refer_posts_from_newres.clear_while_keeping_blocks();
 }
 
 //

--- a/src/article/layouttree.cpp
+++ b/src/article/layouttree.cpp
@@ -110,7 +110,7 @@ void LayoutTree::clear()
     m_separator_header = create_separator();
 
     // 新着返信関連削除
-    if ( m_local_nodetree_newres ) m_local_nodetree_newres->~NodeTreeBase();
+    if ( m_local_nodetree_newres ) delete m_local_nodetree_newres;
     m_local_nodetree_newres = nullptr;
     m_heap_refer_posts_from_newres.clear();
     m_refer_posts_from_newres_number = 0;
@@ -727,9 +727,9 @@ void LayoutTree::create_layout_refer_posts_from_newres()
         html += std::to_string( res_number );
     }
 
-
-    m_local_nodetree_newres = m_heap_refer_posts_from_newres.heap_alloc<DBTREE::NodeTreeBase>();
-    m_local_nodetree_newres = new( m_local_nodetree_newres ) DBTREE::NodeTreeBase( m_url, std::string(), SIZE_OF_HEAP_REFER_POSTS_LOCAL_NODE );
+    if( ! m_local_nodetree_newres ) {
+        m_local_nodetree_newres = new DBTREE::NodeTreeBase( m_url, std::string(), SIZE_OF_HEAP_REFER_POSTS_LOCAL_NODE );
+    }
     DBTREE::NODE* node_header = m_local_nodetree_newres->append_html( html );
 
     append_block( node_header->headinfo->block[ DBTREE::BLOCK_MES ], 0, nullptr, 0, &m_heap_refer_posts_from_newres );
@@ -784,8 +784,7 @@ void LayoutTree::hide_layout_refer_posts_from_newres()
     m_refer_posts_from_newres_header = nullptr;
 
     // 内部 heap 清掃
-    if ( m_local_nodetree_newres ) m_local_nodetree_newres->~NodeTreeBase();
-    m_local_nodetree_newres = nullptr;
+    if ( m_local_nodetree_newres ) m_local_nodetree_newres->clear_while_keeping_blocks();
     m_heap_refer_posts_from_newres.clear_while_keeping_blocks();
 }
 

--- a/src/article/layouttree.h
+++ b/src/article/layouttree.h
@@ -83,12 +83,14 @@ namespace ARTICLE
 
         JDLIB::HEAP *m_heap; // 現在使っているheap
         JDLIB::HEAP m_heap_default; // デフォルトのheap
+        JDLIB::HEAP m_heap_refer_posts_from_newres; // 新着返信用のheap
         std::string m_url;
 
         std::unordered_map< int, LAYOUT* > m_map_header;  // ヘッダのポインタの連想配列
 
         // コメントノードやプレビュー表示時に使うローカルなノードツリー
         DBTREE::NodeTreeBase* m_local_nodetree; 
+        DBTREE::NodeTreeBase* m_local_nodetree_newres{};
 
         LAYOUT* m_root_header;
         LAYOUT* m_last_header;
@@ -97,10 +99,15 @@ namespace ARTICLE
 
         // 新着セパレータ
         LAYOUT* m_separator_header;
+        // 新着返信表示
+        LAYOUT* m_refer_posts_from_newres_header{};
 
         // 新着セパレータの位置(レス番号), 0の時は表示していない
         int m_separator_new;
         int m_separator_new_reserve; // これにレス番号をセットしてから move_separator()を呼ぶ
+
+        // 新着返信表示の位置（レス番号）, 0の時は表示していない
+        int m_refer_posts_from_newres_number{};
 
         // 表示中の最大のレス番号
         int m_max_res_number; 
@@ -156,6 +163,11 @@ namespace ARTICLE
         void move_separator();
         void hide_separator();
         int get_separator_new() const { return m_separator_new; }
+
+        // 新着返信表示関連
+        void create_layout_refer_posts_from_newres();
+        void hide_layout_refer_posts_from_newres();
+        void insert_layout_refer_posts_from_newres();
 
       private:
         

--- a/src/article/layouttree.h
+++ b/src/article/layouttree.h
@@ -81,7 +81,8 @@ namespace ARTICLE
         // 高速化のため直接アクセス
         JDLIB::RefPtr_Lock< DBTREE::ArticleBase > m_article; 
 
-        JDLIB::HEAP m_heap;
+        JDLIB::HEAP *m_heap; // 現在使っているheap
+        JDLIB::HEAP m_heap_default; // デフォルトのheap
         std::string m_url;
 
         std::unordered_map< int, LAYOUT* > m_map_header;  // ヘッダのポインタの連想配列

--- a/src/article/layouttree.h
+++ b/src/article/layouttree.h
@@ -81,7 +81,6 @@ namespace ARTICLE
         // 高速化のため直接アクセス
         JDLIB::RefPtr_Lock< DBTREE::ArticleBase > m_article; 
 
-        JDLIB::HEAP *m_heap; // 現在使っているheap
         JDLIB::HEAP m_heap_default; // デフォルトのheap
         JDLIB::HEAP m_heap_refer_posts_from_newres; // 新着返信用のheap
         std::string m_url;
@@ -134,7 +133,7 @@ namespace ARTICLE
         void clear();
 
         // RECTANGLE型のメモリ確保
-        RECTANGLE* create_rect();
+        RECTANGLE* create_rect( JDLIB::HEAP* heap = nullptr );
 
         LAYOUT* top_header() const { return m_root_header->next_header; }
         const LAYOUT* last_header() const { return m_last_header; }
@@ -145,7 +144,8 @@ namespace ARTICLE
         // joint == true の時はヘッダを作らないで、本文を前のツリーの続きに連結する
         void append_node( DBTREE::NODE* node_header, const bool joint );
 
-        void append_block( DBTREE::NODE* block, const int res_number, IMGDATA* imgdata = nullptr, const int dom_attr = 0 );
+        void append_block( DBTREE::NODE* block, const int res_number, IMGDATA* imgdata = nullptr, const int dom_attr = 0,
+                           JDLIB::HEAP* heap = nullptr );
 
         // html をパースして追加
         void append_html( const std::string& html );
@@ -171,17 +171,20 @@ namespace ARTICLE
 
       private:
         
-        LAYOUT* create_layout( const int type );
+        LAYOUT* create_layout( const int type, JDLIB::HEAP* heap = nullptr );
         LAYOUT* create_layout_header();
-        LAYOUT* create_layout_text( const char* text, const unsigned char* color_text, bool bold );
-        LAYOUT* create_layout_link( const char* text, const char* link, const unsigned char* color_text, bool bold );
-        LAYOUT* create_layout_idnum( const char* text, const unsigned char* color_text, bool bold );
-        LAYOUT* create_layout_br( const bool nobr = false );
-        LAYOUT* create_layout_hr();
-        LAYOUT* create_layout_hspace( const int type );
-        LAYOUT* create_layout_div( const int id );
-        LAYOUT* create_layout_img( const char* link );
-        LAYOUT* create_layout_sssp( const char* link );
+        LAYOUT* create_layout_text( const char* text, const unsigned char* color_text, bool bold,
+                                    JDLIB::HEAP* heap = nullptr );
+        LAYOUT* create_layout_link( const char* text, const char* link, const unsigned char* color_text, bool bold,
+                                    JDLIB::HEAP* heap = nullptr );
+        LAYOUT* create_layout_idnum( const char* text, const unsigned char* color_text, bool bold,
+                                    JDLIB::HEAP* heap = nullptr );
+        LAYOUT* create_layout_br( const bool nobr = false, JDLIB::HEAP* heap = nullptr );
+        LAYOUT* create_layout_hr( JDLIB::HEAP* heap = nullptr );
+        LAYOUT* create_layout_hspace( const int type, JDLIB::HEAP* heap = nullptr );
+        LAYOUT* create_layout_div( const int id, JDLIB::HEAP* heap = nullptr );
+        LAYOUT* create_layout_img( const char* link, JDLIB::HEAP* heap = nullptr );
+        LAYOUT* create_layout_sssp( const char* link, JDLIB::HEAP* heap = nullptr );
 
         void append_abone_node( DBTREE::NODE* node_header );
         LAYOUT* create_separator();

--- a/src/dbtree/articlebase.cpp
+++ b/src/dbtree/articlebase.cpp
@@ -998,6 +998,13 @@ void ArticleBase::clear_post_history()
 }
 
 
+// 新着返信レス取得
+const std::set<int>& ArticleBase::get_refer_posts_from_newres ()
+{
+    return get_nodetree()->get_refer_posts_from_newres();
+}
+
+
 //
 // NodeTree作成
 //

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -19,6 +19,7 @@
 #include <sys/time.h>
 #include <unordered_set>
 #include <vector>
+#include <set>
 
 namespace DBTREE
 {
@@ -262,6 +263,9 @@ namespace DBTREE
 
         // 書き込み履歴のリセット
         void clear_post_history();
+
+        // 新着返信レス取得
+        const std::set<int>& get_refer_posts_from_newres ();
 
         // スレ立て時刻
         time_t get_since_time() const { return m_since_time; };

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -194,6 +194,53 @@ void NodeTreeBase::clear()
 }
 
 
+void NodeTreeBase::clear_while_keeping_blocks()
+{
+    // clear()からコピー
+    //
+    m_buffer_lines.clear();
+    m_parsed_text.clear();
+    m_buffer_write.clear();
+    if( m_fout ) fclose( m_fout );
+    m_fout = nullptr;
+    m_ext_err.clear();
+
+    // ブロックを確保したまま使用状況をリセット
+    m_heap.clear_while_keeping_blocks();
+    m_vec_header.clear();
+    m_posts.clear();
+    m_refer_posts.clear();
+    m_map_future_refer.clear();
+    m_map_id_name_resnumber.clear();
+
+    // コンストラクタからコピー
+    //
+    // ルートヘッダ作成。中は空。
+    m_id_header = -1; // ルートヘッダIDが 0 になるように -1
+    NODE* tmpnode = create_node_header();
+    assert( tmpnode );
+    assert( m_vec_header.size() == static_cast< decltype( m_vec_header.size() ) >( m_id_header ) );
+    m_vec_header.push_back( tmpnode );
+
+    m_default_noname = DBTREE::default_noname( m_url );
+
+    // 参照で色を変える回数
+    m_num_reference[ LINK_HIGH ] = CONFIG::get_num_reference_high();
+    m_num_reference[ LINK_LOW ] = CONFIG::get_num_reference_low();
+
+    // 発言数で色を変える回数
+    m_num_id[ LINK_HIGH ] = CONFIG::get_num_id_high();
+    m_num_id[ LINK_LOW ] = CONFIG::get_num_id_low();
+
+    // レスにアスキーアートがあると判定する正規表現
+    if( CONFIG::get_aafont_enabled() ){
+        m_aa_regex = CONFIG::get_regex_res_aa();
+    } else {
+        m_aa_regex = std::string();
+    }
+}
+
+
 //
 // 総レス数
 //

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -78,14 +78,14 @@ enum
 using namespace DBTREE;
 
 
-NodeTreeBase::NodeTreeBase( const std::string& url, const std::string& modified )
+NodeTreeBase::NodeTreeBase( const std::string& url, const std::string& modified, const size_t heap_size )
     : SKELETON::Loadable(),
       m_url( url ),
       m_lng_dat( 0 ),
       m_resume ( RESUME_NO ),
       m_resume_cached( false ),
       m_broken( false ),
-      m_heap( SIZE_OF_HEAP ),
+      m_heap( heap_size ),
       m_check_update( false ),
       m_check_write( false ),
       m_loading_newthread( false ),
@@ -123,6 +123,11 @@ NodeTreeBase::NodeTreeBase( const std::string& url, const std::string& modified 
     std::cout << "NodeTreeBase::NodeTreeBase url = " << m_url << " modified = " << get_date_modified()
               << " noname = " << m_default_noname << std::endl;
 #endif
+}
+
+NodeTreeBase::NodeTreeBase( const std::string& url, const std::string& modified )
+    : NodeTreeBase( url, modified, SIZE_OF_HEAP )
+{
 }
 
 

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -1506,6 +1506,9 @@ void NodeTreeBase::add_raw_lines( char* rawlines, size_t size )
 
     while( ( pos = add_one_dat_line( pos ) ) && *pos != '\0' ) ++pos;
 
+    // 新着返信履歴削除
+    m_refer_posts_from_newres.clear();
+
     if( num_before != m_id_header ){
 
         // あぼーん判定
@@ -3321,6 +3324,7 @@ void NodeTreeBase::check_reference( const int number )
                     NODE* tmphead = res_header( from );
                     if( tmphead && ! tmphead->headinfo->abone ){
                         m_refer_posts.insert( from );
+                        // 新着からチェックするので、 m_refer_posts_from_newres にはここでは追加しない
                     }
                 }
             }
@@ -3406,6 +3410,7 @@ void NodeTreeBase::check_reference( const int number )
                                 // 自分の書き込みに対するレス
                                 if( posted && m_posts.find( i ) != m_posts.end() ) {
                                     m_refer_posts.insert( number );
+                                    m_refer_posts_from_newres.insert( number );
 
 #ifdef _DEBUG
                                     std::cout << "ref " << i << " from " << number << std::endl;

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -269,6 +269,8 @@ namespace DBTREE
         // 新着返信レス取得
         const std::set<int>& get_refer_posts_from_newres () const noexcept { return m_refer_posts_from_newres; }
 
+        void clear_while_keeping_blocks();
+
       protected:
 
         virtual void clear();

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -104,6 +104,8 @@ namespace DBTREE
 
         // 自分の書き込みにレスしているか
         std::unordered_set< int > m_refer_posts;
+        // 上記の中で、新着のレスの内、自分の書き込みにレスをしているレス番号（新着返信）
+        std::set< int > m_refer_posts_from_newres; // ordered
 
         // 未来のレスに対するアンカーがある時に使用する
         // check_reference() を参照
@@ -261,6 +263,9 @@ namespace DBTREE
 
         // 書き込み履歴のリセット
         void clear_post_history();
+
+        // 新着返信レス取得
+        const std::set<int>& get_refer_posts_from_newres () const noexcept { return m_refer_posts_from_newres; }
 
       protected:
 

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -19,6 +19,7 @@
 #include <cstring>
 #include <unordered_map>
 #include <unordered_set>
+#include <set>
 
 namespace JDLIB
 {

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -143,6 +143,7 @@ namespace DBTREE
 
       public:
 
+        NodeTreeBase( const std::string& url, const std::string& date_modified, const size_t heap_size );
         NodeTreeBase( const std::string& url, const std::string& date_modified );
         ~NodeTreeBase();
 

--- a/src/jdlib/heap.cpp
+++ b/src/jdlib/heap.cpp
@@ -9,12 +9,15 @@
 
 #include "heap.h"
 
+#include <cstring>
+
 using namespace JDLIB;
 
 HEAP::HEAP( std::size_t blocksize ) noexcept
     : m_blocksize{ blocksize }
     , m_space_avail{ 0 }
     , m_ptr_head{ nullptr }
+    , m_block_iter{ m_heap_list.end() } // std::listは要素追加でイテレーターが無効にならない
 {}
 
 
@@ -29,6 +32,15 @@ void HEAP::clear()
     m_heap_list.clear();
     m_space_avail = 0;
     m_ptr_head = nullptr;
+    m_block_iter = m_heap_list.end();
+}
+
+
+void HEAP::clear_while_keeping_blocks()
+{
+    m_space_avail = 0;
+    m_ptr_head = nullptr;
+    m_block_iter = m_heap_list.begin();
 }
 
 
@@ -39,9 +51,18 @@ void* HEAP::heap_alloc( std::size_t size_bytes, std::size_t alignment )
 
     while(1) {
         if( !m_ptr_head || m_space_avail < size_bytes || m_space_avail >= m_blocksize ) {
-            // 確保したメモリブロックはゼロ初期化する
-            m_heap_list.emplace_back( new unsigned char[m_blocksize]{} );
-            m_ptr_head = &m_heap_list.back()[0];
+            if( m_block_iter != m_heap_list.end() ) {
+                // メモリブロックは使う前にzero-fillする
+                m_ptr_head = &(*m_block_iter)[0];
+                std::memset( m_ptr_head, 0, sizeof(unsigned char) * m_blocksize );
+                ++m_block_iter;
+            }
+            else {
+                // イテレーターがendを指しているときはブロックを追加
+                // 確保したメモリブロックはゼロ初期化する
+                m_heap_list.emplace_back( new unsigned char[m_blocksize]{} );
+                m_ptr_head = &m_heap_list.back()[0];
+            }
             m_space_avail = m_blocksize - 1;
         }
 

--- a/src/jdlib/heap.h
+++ b/src/jdlib/heap.h
@@ -13,10 +13,13 @@ namespace JDLIB
 {
     class HEAP
     {
-        std::list< std::unique_ptr<unsigned char[]> > m_heap_list;
+        using BlockList = std::list< std::unique_ptr<unsigned char[]> >;
+
+        BlockList m_heap_list;
         std::size_t m_blocksize; // ブロックサイズ
         std::size_t m_space_avail; // ブロックの未使用サイズ
         void* m_ptr_head; // 検索開始位置
+        BlockList::iterator m_block_iter; // ブロックを再利用するためのイテレーター
 
       public:
         HEAP( std::size_t blocksize ) noexcept;
@@ -27,7 +30,8 @@ namespace JDLIB
         HEAP( HEAP&& ) noexcept = default;
         HEAP& operator=( HEAP&& ) = default;
 
-        void clear();
+        void clear(); // 確保したブロックを解放する
+        void clear_while_keeping_blocks(); // 確保したブロックを再利用する
 
         // 戻り値はunsigned char*のエイリアス
         void* heap_alloc( std::size_t size_bytes, std::size_t alignment );


### PR DESCRIPTION
新着返信の表示(JDimproved#230)の修正アイデアです。コピペの部分があり完成度は高くないです。

@mtasaka さんの修正に以下の変更を付け足します。

- `JDLIB::HEAP`クラスに確保したメモリブロックを維持したまま利用状況をリセットする`clear_while_keeping_blocks()`を追加する(6fcb630)

- `LayoutTree`クラスのレイアウト作成関数の引数にheapを渡すように変更した（メール欄フォントの`fontid`と同じ方法 JDimproved#195）(e766af2)

- `NodeTreeBase`クラスに確保したメモリブロックを維持したまま利用状況をリセットする`clear_while_keeping_blocks()`を追加する(76d52c1)

全部のレスに書き込みマークを付ける極端なケースをテストしてみましたが新着返信の機能を追加した分(NodeTree + LayoutTree)だけメモリ使用量が増えているようです。
