### PR TITLE
書き込み用キーワードの処理を更新する

### DIFF
--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -416,7 +416,7 @@ void Preferences::slot_set_default_namemail()
 
 void Preferences::slot_delete_cookie()
 {
-    DBTREE::board_delete_cookies_for_request( get_url() );
+    DBTREE::board_delete_cookies( get_url() );
     DBTREE::board_set_keyword_for_write( get_url(), std::string() );
 
     m_edit_cookies.set_text( "クッキー:\n未取得\n" );

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -104,7 +104,7 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
 
     // cookie と 書き込みキーワード の設定
     std::string str_cookies;
-    const std::string temp_cookies = DBTREE::board_cookie_for_request( get_url() );
+    const std::string temp_cookies = DBTREE::board_cookie_by_host( get_url() );
     if( temp_cookies.empty() ) {
         str_cookies = "クッキー:\n未取得\n";
     }

--- a/src/board/preference.cpp
+++ b/src/board/preference.cpp
@@ -112,8 +112,11 @@ Preferences::Preferences( Gtk::Window* parent, const std::string& url, const std
         str_cookies = "クッキー:\n" + MISC::Iconv( temp_cookies, DBTREE::board_charset( get_url() ), "UTF-8" ) + "\n";
     }
 
-    const std::string keyword = DBTREE::board_keyword_for_write( get_url() );
-    if( ! keyword.empty() ) str_cookies += "\nキーワード: " + keyword + "\n";
+    std::string keyword = DBTREE::board_keyword_for_write( get_url() );
+    if( ! keyword.empty() ) str_cookies.append( "\n書き込み用キーワード: " + keyword + "\n" );
+
+    keyword = DBTREE::board_keyword_for_newarticle( get_url() );
+    if( ! keyword.empty() ) str_cookies.append( "\nスレ立て用キーワード: " + keyword + "\n" );
 
     m_edit_cookies.set_text( str_cookies );
 
@@ -418,6 +421,7 @@ void Preferences::slot_delete_cookie()
 {
     DBTREE::board_delete_cookies( get_url() );
     DBTREE::board_set_keyword_for_write( get_url(), std::string() );
+    DBTREE::board_set_keyword_for_newarticle( get_url(), std::string() );
 
     m_edit_cookies.set_text( "クッキー:\n未取得\n" );
 }

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -109,18 +109,23 @@ bool ConfigItems::load( const bool restore )
 
     // 読み込み用プロクシとポート番号
     use_proxy_for2ch = cf.get_option_bool( "use_proxy_for2ch", CONF_USE_PROXY_FOR2CH );
+    send_cookie_to_proxy_for2ch = cf.get_option_bool( "send_cookie_to_proxy_for2ch", CONF_SEND_COOKIE_TO_PROXY_FOR2CH );
     str_tmp = cf.get_option_str( "proxy_for2ch", "" );
     set_proxy_for2ch( str_tmp );
     proxy_port_for2ch = cf.get_option_int( "proxy_port_for2ch", CONF_PROXY_PORT_FOR2CH, 1, 65535 );
 
     // 書き込み用プロクシとポート番号
     use_proxy_for2ch_w = cf.get_option_bool( "use_proxy_for2ch_w", CONF_USE_PROXY_FOR2CH_W );
+    send_cookie_to_proxy_for2ch_w = cf.get_option_bool( "send_cookie_to_proxy_for2ch_w",
+                                                        CONF_SEND_COOKIE_TO_PROXY_FOR2CH_W );
     str_tmp = cf.get_option_str( "proxy_for2ch_w", "" );
     set_proxy_for2ch_w( str_tmp );
     proxy_port_for2ch_w = cf.get_option_int( "proxy_port_for2ch_w", CONF_PROXY_PORT_FOR2CH_W, 1, 65535 );
 
     // 2chの外にアクセスするときのプロクシとポート番号
     use_proxy_for_data = cf.get_option_bool( "use_proxy_for_data", CONF_USE_PROXY_FOR_DATA );
+    send_cookie_to_proxy_for_data = cf.get_option_bool( "send_cookie_to_proxy_for_data",
+                                                        CONF_SEND_COOKIE_TO_PROXY_FOR_DATA );
     str_tmp = cf.get_option_str( "proxy_for_data", "" );
     set_proxy_for_data( str_tmp );
     proxy_port_for_data = cf.get_option_int( "proxy_port_for_data", CONF_PROXY_PORT_FOR_DATA, 1, 65535 );
@@ -670,12 +675,14 @@ void ConfigItems::save_impl( const std::string& path )
     if( proxy_basicauth_for2ch.empty() ) tmp_proxy = proxy_for2ch;
     else tmp_proxy = proxy_basicauth_for2ch + "@" + proxy_for2ch;
     cf.update( "use_proxy_for2ch", use_proxy_for2ch );
+    cf.update( "send_cookie_to_proxy_for2ch", send_cookie_to_proxy_for2ch );
     cf.update( "proxy_for2ch", tmp_proxy );
     cf.update( "proxy_port_for2ch", proxy_port_for2ch );
 
     if( proxy_basicauth_for2ch_w.empty() ) tmp_proxy = proxy_for2ch_w;
     else tmp_proxy = proxy_basicauth_for2ch_w + "@" + proxy_for2ch_w;
     cf.update( "use_proxy_for2ch_w", use_proxy_for2ch_w );
+    cf.update( "send_cookie_to_proxy_for2ch_w", send_cookie_to_proxy_for2ch_w );
     cf.update( "proxy_for2ch_w", tmp_proxy );
     cf.update( "proxy_port_for2ch_w", proxy_port_for2ch_w );
 
@@ -684,6 +691,7 @@ void ConfigItems::save_impl( const std::string& path )
     if( proxy_basicauth_for_data.empty() ) tmp_proxy = proxy_for_data;
     else tmp_proxy = proxy_basicauth_for_data + "@" + proxy_for_data;
     cf.update( "use_proxy_for_data", use_proxy_for_data );
+    cf.update( "send_cookie_to_proxy_for_data", send_cookie_to_proxy_for_data );
     cf.update( "proxy_for_data", tmp_proxy );
     cf.update( "proxy_port_for_data", proxy_port_for_data );
 

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -49,18 +49,21 @@ namespace CONFIG
 
         // 読み込み用プロクシとポート番号
         bool use_proxy_for2ch{};
+        bool send_cookie_to_proxy_for2ch{};
         std::string proxy_for2ch;
         int proxy_port_for2ch{};
         std::string proxy_basicauth_for2ch;
 
         // 書き込み用プロクシとポート番号
         bool use_proxy_for2ch_w{};
+        bool send_cookie_to_proxy_for2ch_w{};
         std::string proxy_for2ch_w;
         int proxy_port_for2ch_w{};
         std::string proxy_basicauth_for2ch_w;
 
         // 2chの外にアクセスするときのプロクシとポート番号
         bool use_proxy_for_data{};
+        bool send_cookie_to_proxy_for_data{};
         std::string proxy_for_data;
         int proxy_port_for_data{};
         std::string proxy_basicauth_for_data;

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -23,10 +23,13 @@ namespace CONFIG
 #endif
         CONF_REF_PREFIX_SPACE = 1, // 参照文字( CONF_REF_PREFIX ) の後のスペースの数
         CONF_USE_PROXY_FOR2CH = 0, // 2ch 読み込み用プロクシを使用するか
+        CONF_SEND_COOKIE_TO_PROXY_FOR2CH = 0, // 2ch 読み込み用プロクシにクッキーを送信するか
         CONF_PROXY_PORT_FOR2CH = 8080, // 2ch 読み込み用プロクシポート番号
         CONF_USE_PROXY_FOR2CH_W = 0, // 2ch 書き込み用プロクシを使用するか
+        CONF_SEND_COOKIE_TO_PROXY_FOR2CH_W = 0, // 2ch 書き込み用プロクシにクッキーを送信するか
         CONF_PROXY_PORT_FOR2CH_W = 8080, // 2ch 書き込み用プロクシポート番号
         CONF_USE_PROXY_FOR_DATA = 0, // 2ch 以外にアクセスするときにプロクシを使用するか
+        CONF_SEND_COOKIE_TO_PROXY_FOR_DATA = 0, // 2ch 以外にアクセスするときのプロクシにクッキーを送信するか
         CONF_PROXY_PORT_FOR_DATA = 8080, // 2ch 以外にアクセスするときのプロクシポート番号
         CONF_LOADER_BUFSIZE = 32,   // ローダのバッファサイズ (一般)
         CONF_LOADER_BUFSIZE_BOARD = 2,   // ローダのバッファサイズ (スレ一覧用)

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -181,26 +181,31 @@ const std::string& CONFIG::get_url_search_web(){ return get_confitem()->url_sear
 const std::string& CONFIG::get_agent_for2ch() { return get_confitem()->agent_for2ch; }
 
 bool CONFIG::get_use_proxy_for2ch() { return get_confitem()->use_proxy_for2ch; }
+bool CONFIG::get_send_cookie_to_proxy_for2ch() { return get_confitem()->send_cookie_to_proxy_for2ch; }
 const std::string& CONFIG::get_proxy_for2ch() { return get_confitem()->proxy_for2ch; }
 int CONFIG::get_proxy_port_for2ch() { return get_confitem()->proxy_port_for2ch; }
 const std::string& CONFIG::get_proxy_basicauth_for2ch() { return get_confitem()->proxy_basicauth_for2ch; }
 
 void CONFIG::set_use_proxy_for2ch( bool set ){ get_confitem()->use_proxy_for2ch = set; }
+void CONFIG::set_send_cookie_to_proxy_for2ch( bool set ){ get_confitem()->send_cookie_to_proxy_for2ch = set; }
 void CONFIG::set_proxy_for2ch( const std::string& proxy ){ get_confitem()->set_proxy_for2ch( proxy ); }
 void CONFIG::set_proxy_port_for2ch( int port ){ get_confitem()->proxy_port_for2ch = port; }
 
 bool CONFIG::get_use_proxy_for2ch_w() { return get_confitem()->use_proxy_for2ch_w; }
+bool CONFIG::get_send_cookie_to_proxy_for2ch_w() { return get_confitem()->send_cookie_to_proxy_for2ch_w; }
 const std::string& CONFIG::get_proxy_for2ch_w() { return get_confitem()->proxy_for2ch_w; }
 int CONFIG::get_proxy_port_for2ch_w() { return get_confitem()->proxy_port_for2ch_w; }
 const std::string& CONFIG::get_proxy_basicauth_for2ch_w() { return get_confitem()->proxy_basicauth_for2ch_w; }
 
 void CONFIG::set_use_proxy_for2ch_w( bool set ){ get_confitem()->use_proxy_for2ch_w = set; }
+void CONFIG::set_send_cookie_to_proxy_for2ch_w( bool set ){ get_confitem()->send_cookie_to_proxy_for2ch_w = set; }
 void CONFIG::set_proxy_for2ch_w( const std::string& proxy ){ get_confitem()->set_proxy_for2ch_w( proxy ); }
 void CONFIG::set_proxy_port_for2ch_w( int port ){ get_confitem()->proxy_port_for2ch_w = port; }
 
 const std::string& CONFIG::get_agent_for_data() { return get_confitem()->agent_for_data; }
 
 bool CONFIG::get_use_proxy_for_data() { return get_confitem()->use_proxy_for_data; }
+bool CONFIG::get_send_cookie_to_proxy_for_data() { return get_confitem()->send_cookie_to_proxy_for_data; }
 const std::string& CONFIG::get_proxy_for_data() { return get_confitem()->proxy_for_data; }
 int CONFIG::get_proxy_port_for_data() { return get_confitem()->proxy_port_for_data; }
 const std::string& CONFIG::get_proxy_basicauth_for_data() { return get_confitem()->proxy_basicauth_for_data; }
@@ -208,6 +213,7 @@ const std::string& CONFIG::get_proxy_basicauth_for_data() { return get_confitem(
 const std::string& CONFIG::get_x_2ch_ua() { return get_confitem()->x_2ch_ua; }
 
 void CONFIG::set_use_proxy_for_data( bool set ){ get_confitem()->use_proxy_for_data = set; }
+void CONFIG::set_send_cookie_to_proxy_for_data( bool set ){ get_confitem()->send_cookie_to_proxy_for_data = set; }
 void CONFIG::set_proxy_for_data( const std::string& proxy ){ get_confitem()->set_proxy_for_data( proxy ); }
 void CONFIG::set_proxy_port_for_data( int port ){ get_confitem()->proxy_port_for_data = port; }
 

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -143,21 +143,25 @@ namespace CONFIG
 
     // 2ch 読み込み用プロクシとポート番号
     bool get_use_proxy_for2ch();
+    bool get_send_cookie_to_proxy_for2ch();
     const std::string& get_proxy_for2ch();
     int get_proxy_port_for2ch();
     const std::string& get_proxy_basicauth_for2ch();
 
     void set_use_proxy_for2ch( const bool set );
+    void set_send_cookie_to_proxy_for2ch( bool set );
     void set_proxy_for2ch( const std::string& proxy );
     void set_proxy_port_for2ch( const int port );
 
     // 2ch 書き込み用プロクシとポート番号
     bool get_use_proxy_for2ch_w();
+    bool get_send_cookie_to_proxy_for2ch_w();
     const std::string& get_proxy_for2ch_w();
     int get_proxy_port_for2ch_w();
     const std::string& get_proxy_basicauth_for2ch_w();
 
     void set_use_proxy_for2ch_w( const bool set );
+    void set_send_cookie_to_proxy_for2ch_w( bool set );
     void set_proxy_for2ch_w( const std::string& proxy );
     void set_proxy_port_for2ch_w( const int port );
 
@@ -166,11 +170,13 @@ namespace CONFIG
 
     // 2chの外にアクセスするときのプロクシとポート番号
     bool get_use_proxy_for_data();
+    bool get_send_cookie_to_proxy_for_data();
     const std::string& get_proxy_for_data();
     int get_proxy_port_for_data();
     const std::string& get_proxy_basicauth_for_data();
 
     void set_use_proxy_for_data( const bool set );
+    void set_send_cookie_to_proxy_for_data( bool set );
     void set_proxy_for_data( const std::string& proxy );
     void set_proxy_port_for_data( const int port );
 

--- a/src/dbtree/Makefile.am
+++ b/src/dbtree/Makefile.am
@@ -12,6 +12,7 @@ libdbtree_a_SOURCES = \
 	boardmachi.cpp \
 	boardlocal.cpp \
 \
+	frontloader.cpp \
 	settingloader.cpp \
 	ruleloader.cpp \
 	boardfactory.cpp \
@@ -46,6 +47,7 @@ noinst_HEADERS = \
 	boardjbbs.h \
 	boardmachi.h \
 \
+	frontloader.h \
 	settingloader.h \
 	ruleloader.h \
 	boardfactory.h \

--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -116,26 +116,61 @@ std::string Board2ch::get_proxy_basicauth_w()
 }
 
 
-// 読み書き用クッキー作成
-std::string Board2ch::cookie_for_request() const
+// BE 用クッキー作成
+void Board2ch::set_cookie_for_be( std::string& cookie ) const
 {
-#ifdef _DEBUG
-    std::cout << "Board2ch::cookie_for_request\n";
-#endif
-
-    std::string cookie = Board2chCompati::cookie_for_request();
-    if( cookie.empty() ) cookie = get_hap();
-
     // BE ログイン中
-    if( CORE::get_loginbe()->login_now() ){
+    if( CORE::get_loginbe()->login_now() ) {
         if( ! cookie.empty() ) cookie += "; ";
         cookie += "DMDM=" + CORE::get_loginbe()->get_sessionid() + "; MDMD=" + CORE::get_loginbe()->get_sessiondata();
     }
+}
+
+
+//
+// 読み込み用クッキー作成
+//
+// プロキシの2ch読み込み用設定がoffのとき
+// またはプロキシにクッキーを送る設定のときは対象サイトにcookieを送信する
+//
+std::string Board2ch::cookie_for_request() const
+{
+    std::string cookie;
+
+    if( ! CONFIG::get_use_proxy_for2ch() || CONFIG::get_send_cookie_to_proxy_for2ch() ) {
+        cookie = cookie_by_host();
+        if( cookie.empty() ) cookie = get_hap();
+    }
+
+    set_cookie_for_be( cookie );
 
 #ifdef _DEBUG
-    std::cout << "cookie = " << cookie << std::endl;
-#endif 
+    std::cout << "Board2ch::cookie_for_request cookie = " << cookie << std::endl;
+#endif
+    return cookie;
+}
 
+
+//
+// 書き込み用クッキー作成
+//
+// プロキシの2ch書き込み用設定がoffのとき
+// またはプロキシにクッキーを送る設定のときは対象サイトにcookieを送信する
+//
+std::string Board2ch::cookie_for_post() const
+{
+    std::string cookie;
+
+    if( ! CONFIG::get_use_proxy_for2ch_w() || CONFIG::get_send_cookie_to_proxy_for2ch_w() ) {
+        cookie = cookie_by_host();
+        if( cookie.empty() ) cookie = get_hap();
+    }
+
+    set_cookie_for_be( cookie );
+
+#ifdef _DEBUG
+    std::cout << "Board2ch::cookie_for_post cookie = " << cookie << std::endl;
+#endif
     return cookie;
 }
 

--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -124,7 +124,7 @@ std::string Board2ch::cookie_for_request() const
 #endif
 
     std::string cookie = Board2chCompati::cookie_for_request();
-    if( cookie.empty() ) cookie = get_cookie();
+    if( cookie.empty() ) cookie = get_hap();
 
     // BE ログイン中
     if( CORE::get_loginbe()->login_now() ){
@@ -231,7 +231,7 @@ ArticleBase* Board2ch::append_article( const std::string& datbase, const std::st
 
 
 // 2chのクッキー
-std::string Board2ch::get_cookie() const
+std::string Board2ch::get_hap() const
 {
     if( ! CONFIG::get_use_cookie_hap() ) return std::string();
 
@@ -239,30 +239,30 @@ std::string Board2ch::get_cookie() const
     return CONFIG::get_cookie_hap();
 }
 
-void Board2ch::set_cookie( const std::string& cookie )
+void Board2ch::set_hap( const std::string& hap )
 {
     if( ! CONFIG::get_use_cookie_hap() )  return;
 
-    if( get_root().find( ".bbspink.com" ) != std::string::npos ) CONFIG::set_cookie_hap_bbspink( cookie );
-    else CONFIG::set_cookie_hap( cookie );
+    if( get_root().find( ".bbspink.com" ) != std::string::npos ) CONFIG::set_cookie_hap_bbspink( hap );
+    else CONFIG::set_cookie_hap( hap );
 }
 
 
 //
 // 2chのクッキーの更新
 //
-void Board2ch::update_cookie()
+void Board2ch::update_hap()
 {
     if( ! CONFIG::get_use_cookie_hap() ) return;
 
     const std::string new_cookie = Board2chCompati::cookie_for_request();
 
     if( ! new_cookie.empty() ) {
-        const std::string old_cookie = get_cookie();
-        set_cookie( new_cookie );
+        const std::string old_cookie = get_hap();
+        set_hap( new_cookie );
 #ifdef _DEBUG
-        std::cout << "Board2ch::update_cookie old = " << old_cookie << std::endl;
-        std::cout << "Board2ch::update_cookie new = " << new_cookie << std::endl;
+        std::cout << "Board2ch::update_hap old = " << old_cookie << std::endl;
+        std::cout << "Board2ch::update_hap new = " << new_cookie << std::endl;
 #endif
     }
 }

--- a/src/dbtree/board2ch.cpp
+++ b/src/dbtree/board2ch.cpp
@@ -6,6 +6,7 @@
 #include "board2ch.h"
 #include "article2ch.h"
 #include "articlehash.h"
+#include "frontloader.h"
 
 #include "config/globalconf.h"
 
@@ -29,7 +30,12 @@ Board2ch::Board2ch( const std::string& root, const std::string& path_board, cons
 }
 
 
-Board2ch::~Board2ch() noexcept = default;
+Board2ch::~Board2ch() noexcept
+{
+    if( m_frontloader ) {
+        m_frontloader->terminate_load();
+    }
+}
 
 
 // ユーザエージェント
@@ -178,6 +184,15 @@ std::string Board2ch::cookie_for_post() const
 std::string Board2ch::get_write_referer()
 {
     return Board2chCompati::get_write_referer();
+}
+
+
+// フロントページのダウンロード
+void Board2ch::download_front()
+{
+    if( ! m_frontloader ) m_frontloader.reset( new FrontLoader( url_boardbase() ) );
+    m_frontloader->reset();
+    m_frontloader->download_text();
 }
 
 

--- a/src/dbtree/board2ch.h
+++ b/src/dbtree/board2ch.h
@@ -60,11 +60,11 @@ namespace DBTREE
       protected:
 
         // クッキー
-        std::string get_cookie() const override;
-        void set_cookie( const std::string& cookie ) override;
+        std::string get_hap() const override;
+        void set_hap( const std::string& hap ) override;
 
         // クッキーの更新 (クッキーをセットした時に実行)
-        void update_cookie() override;
+        void update_hap() override;
 
       private:
 

--- a/src/dbtree/board2ch.h
+++ b/src/dbtree/board2ch.h
@@ -9,8 +9,13 @@
 
 #include "board2chcompati.h"
 
+#include <memory>
+
+
 namespace DBTREE
 {
+    class FrontLoader;
+
     enum
     {
         DEFAULT_NUMBER_MAX_2CH = 1000,  // デフォルト最大レス数
@@ -19,6 +24,8 @@ namespace DBTREE
 
     class Board2ch : public Board2chCompati
     {
+        std::unique_ptr<FrontLoader> m_frontloader;
+
       public:
 
         Board2ch( const std::string& root, const std::string& path_board,const std::string& name );
@@ -45,6 +52,9 @@ namespace DBTREE
 
         // 書き込み時のリファラ
         std::string get_write_referer() override;
+
+        // フロントページのダウンロード
+        void download_front() override;
 
         // 新スレ作成用のメッセージ変換
         std::string create_newarticle_message( const std::string& subject, const std::string& name,

--- a/src/dbtree/board2ch.h
+++ b/src/dbtree/board2ch.h
@@ -38,8 +38,10 @@ namespace DBTREE
         int get_proxy_port_w() override;
         std::string get_proxy_basicauth_w() override;
 
-        // 読み書き用クッキー
+        // 読み込み用クッキー
         std::string cookie_for_request() const override;
+        // 書き込み用クッキー
+        std::string cookie_for_post() const override;
 
         // 書き込み時のリファラ
         std::string get_write_referer() override;
@@ -72,6 +74,8 @@ namespace DBTREE
         int get_default_number_max_res() override { return DEFAULT_NUMBER_MAX_2CH; }
 
         ArticleBase* append_article( const std::string& datbase, const std::string& id, const bool cached ) override;
+
+        void set_cookie_for_be( std::string& cookie ) const;
     };
 }
 

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -87,35 +87,29 @@ bool Board2chCompati::is_valid( const std::string& filename )
 }
 
 
-// 書き込み時に必要なキーワード( hana=mogera や suka=pontan など )を
-// 確認画面のhtmlから解析する      
-void Board2chCompati::analyze_keyword_for_write( const std::string& html )
+std::string Board2chCompati::analyze_keyword_impl( const std::string& html )
 {
     std::string keyword;
 
-#ifdef _DEBUG
-    std::cout << "Board2chCompati::analyze_keyword_for_write\n";
-    std::cout << html << std::endl << "--------------------\n";
-#endif
-
     JDLIB::Regex regex;
-    size_t offset = 0;
-    const bool icase = true; // 大文字小文字区別しない
-    const bool newline = false;  // . に改行をマッチさせる
-    const bool usemigemo = false;
-    const bool wchar = false;
+    std::size_t offset = 0;
+    constexpr bool icase = true; // 大文字小文字区別しない
+    constexpr bool newline = false;  // . に改行をマッチさせる
+    constexpr bool usemigemo = false;
+    constexpr bool wchar = false;
 
     for(;;){
 
         // <input type=hidden> のタグを解析して name と value を取得
-        if( ! regex.exec( "<input +type=hidden +name=([^ ]*) +value=([^>]*)>", html, offset, icase, newline, usemigemo, wchar ) ) break;
+        constexpr const char regex_input[] = R"(<input +type=("hidden"|hidden) +name=([^ ]*) +value=([^>]*)>)";
+        if( ! regex.exec( regex_input, html, offset, icase, newline, usemigemo, wchar ) ) break;
 
-        offset = html.find( regex.str( 0 ) );
+        offset = regex.pos( 0 );
 
-        std::string name = MISC::remove_space( regex.str( 1 ) );
+        std::string name = MISC::remove_space( regex.str( 2 ) );
         if( name[ 0 ] == '\"' ) name = MISC::cut_str( name, "\"", "\"" );
 
-        std::string value = MISC::remove_space( regex.str( 2 ) );
+        std::string value = MISC::remove_space( regex.str( 3 ) );
         if( value[ 0 ] == '\"' ) value = MISC::cut_str( value, "\"", "\"" );
 
 #ifdef _DEBUG
@@ -142,9 +136,23 @@ void Board2chCompati::analyze_keyword_for_write( const std::string& html )
     }
 
 #ifdef _DEBUG
-    std::cout << "keyword = " << keyword << std::endl;
+    std::cout << "Board2chCompati::analyze_keyword_impl keyword = " << keyword << std::endl;
 #endif
 
+    return keyword;
+}
+
+
+// 書き込み時に必要なキーワード( hana=mogera や suka=pontan など )を
+// 確認画面のhtmlから解析する
+void Board2chCompati::analyze_keyword_for_write( const std::string& html )
+{
+#ifdef _DEBUG
+    std::cout << "Board2chCompati::analyze_keyword_for_write\n";
+    std::cout << html << std::endl << "--------------------\n";
+#endif
+
+    std::string keyword = analyze_keyword_impl( html );
     set_keyword_for_write( keyword );
 }
 

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -87,13 +87,6 @@ bool Board2chCompati::is_valid( const std::string& filename )
 }
 
 
-// 読み書き用クッキー作成
-std::string Board2chCompati::cookie_for_request() const
-{
-    return BoardBase::cookie_for_request();
-}
-
-
 // 書き込み時に必要なキーワード( hana=mogera や suka=pontan など )を
 // 確認画面のhtmlから解析する      
 void Board2chCompati::analyze_keyword_for_write( const std::string& html )

--- a/src/dbtree/board2chcompati.cpp
+++ b/src/dbtree/board2chcompati.cpp
@@ -157,6 +157,19 @@ void Board2chCompati::analyze_keyword_for_write( const std::string& html )
 }
 
 
+// スレ立て時に必要なキーワードをフロントページのhtmlから解析する
+void Board2chCompati::analyze_keyword_for_newarticle( const std::string& html )
+{
+#ifdef _DEBUG
+    std::cout << "Board2chCompati::analyze_keyword_for_newarticle\n";
+    std::cout << html << std::endl << "--------------------\n";
+#endif
+
+    std::string keyword = analyze_keyword_impl( html );
+    set_keyword_for_newarticle( keyword );
+}
+
+
 // 新スレ作成時の書き込みメッセージ作成
 std::string Board2chCompati::create_newarticle_message( const std::string& subject,
                                                        const std::string& name, const std::string& mail, const std::string& msg )

--- a/src/dbtree/board2chcompati.h
+++ b/src/dbtree/board2chcompati.h
@@ -24,11 +24,6 @@ namespace DBTREE
         Board2chCompati( const std::string& root, const std::string& path_board, const std::string& name, const std::string& basicauth );
         ~Board2chCompati();
 
-        // 読み込み用クッキー
-        using BoardBase::cookie_for_request;
-        // 書き込み用クッキー
-        using BoardBase::cookie_for_post;
-
         // 書き込み時に必要なキーワード( hana=mogera や suka=pontan など )を
         // 確認画面のhtmlから解析する      
         void analyze_keyword_for_write( const std::string& html ) override;

--- a/src/dbtree/board2chcompati.h
+++ b/src/dbtree/board2chcompati.h
@@ -33,6 +33,9 @@ namespace DBTREE
         // 確認画面のhtmlから解析する      
         void analyze_keyword_for_write( const std::string& html ) override;
 
+        // スレ立て時に必要なキーワードをフロントページのhtmlから解析する
+        void analyze_keyword_for_newarticle( const std::string& html ) override;
+
         // 新スレ作成用のメッセージ変換
         std::string create_newarticle_message( const std::string& subject, const std::string& name,
                                                const std::string& mail, const std::string& msg ) override;

--- a/src/dbtree/board2chcompati.h
+++ b/src/dbtree/board2chcompati.h
@@ -66,6 +66,9 @@ namespace DBTREE
 
         // レス数であぼーん(グローバル)
         int get_abone_number_global() override;
+
+        // htmlからキーワードを解析する
+        std::string analyze_keyword_impl( const std::string& html );
     };
 }
 

--- a/src/dbtree/board2chcompati.h
+++ b/src/dbtree/board2chcompati.h
@@ -24,8 +24,10 @@ namespace DBTREE
         Board2chCompati( const std::string& root, const std::string& path_board, const std::string& name, const std::string& basicauth );
         ~Board2chCompati();
 
-        // 読み書き用クッキー
-        std::string cookie_for_request() const override;
+        // 読み込み用クッキー
+        using BoardBase::cookie_for_request;
+        // 書き込み用クッキー
+        using BoardBase::cookie_for_post;
 
         // 書き込み時に必要なキーワード( hana=mogera や suka=pontan など )を
         // 確認画面のhtmlから解析する      

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -286,12 +286,8 @@ std::string BoardBase::cookie_for_request() const
 
 
 // 板のホストを指定してクッキーを追加
-void BoardBase::set_list_cookies_for_request( const std::list< std::string >& list_cookies )
+void BoardBase::set_list_cookies( const std::list< std::string >& list_cookies )
 {
-#ifdef _DEBUG
-    std::cout << "BoardBase::set_list_cookies_for_request\n";
-#endif
-
     JDLIB::CookieManager* cookie_manager = JDLIB::get_cookie_manager();
     const std::string hostname = MISC::get_hostname( get_root(), false );
 

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -276,12 +276,46 @@ std::string BoardBase::get_unicode()
 
 
 // 板のホストを指定してクッキーを取得
-std::string BoardBase::cookie_for_request() const
+std::string BoardBase::cookie_by_host() const
 {
     const JDLIB::CookieManager* cookie_manager = JDLIB::get_cookie_manager();
     const std::string hostname = MISC::get_hostname( get_root(), false );
 
     return cookie_manager->get_cookie_by_host( hostname );
+}
+
+
+//
+// 読み込み用クッキー作成
+//
+// プロキシの読み込み用設定がoffのとき
+// またはプロキシにクッキーを送る設定がonのときはサイトにcookieを送信する
+//
+std::string BoardBase::cookie_for_request() const
+{
+    std::string cookie;
+
+    if( ! CONFIG::get_use_proxy_for_data() || CONFIG::get_send_cookie_to_proxy_for_data() ) {
+        cookie = cookie_by_host();
+    }
+    return cookie;
+}
+
+
+//
+// 書き込み用クッキー作成
+//
+// プロキシの書き込み用設定がoffのとき
+// またはプロキシにクッキーを送る設定がonのときはサイトにcookieを送信する
+//
+std::string BoardBase::cookie_for_post() const
+{
+    std::string cookie;
+
+    if( ! CONFIG::get_use_proxy_for_data() || CONFIG::get_send_cookie_to_proxy_for_data() ) {
+        cookie = cookie_by_host();
+    }
+    return cookie;
 }
 
 

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -299,7 +299,7 @@ void BoardBase::set_list_cookies_for_request( const std::list< std::string >& li
         cookie_manager->feed( hostname, MISC::remove_space( input ) );
     }
 
-    update_cookie();
+    update_hap();
 }
 
 

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -300,7 +300,7 @@ void BoardBase::set_list_cookies( const std::list< std::string >& list_cookies )
 
 
 // 板のホストを指定してクッキーを削除
-void BoardBase::delete_cookies_for_request()
+void BoardBase::delete_cookies()
 {
     JDLIB::CookieManager* cookie_manager = JDLIB::get_cookie_manager();
     const std::string hostname = MISC::get_hostname( get_root(), false );

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -192,6 +192,10 @@ namespace DBTREE
         // 書き込み時のメッセージに付加する
         std::string m_keyword_for_write;   
 
+        // スレ立て時に必要なキーワード
+        // スレ立て時のメッセージに付加する
+        std::string m_keyword_for_newarticle;
+
         // basic 認証用の「ユーザID:パスワード」の組
         std::string m_basicauth;
 
@@ -336,9 +340,17 @@ namespace DBTREE
         const std::string& get_keyword_for_write() const { return m_keyword_for_write; }
         void set_keyword_for_write( const std::string& keyword ){ m_keyword_for_write = keyword; }
 
+        // スレ立て時に必要なキーワード
+        // スレ立て時のメッセージに付加する
+        const std::string& get_keyword_for_newarticle() const { return m_keyword_for_newarticle; }
+        void set_keyword_for_newarticle( const std::string& keyword ){ m_keyword_for_newarticle = keyword; }
+
         // 書き込み時に必要なキーワード( hana=mogera や suka=pontan など )を
         // 確認画面のhtmlから解析する      
         virtual void analyze_keyword_for_write( const std::string& html ){}
+
+        // スレ立て時に必要なキーワードをフロントページのhtmlから解析する
+        virtual void analyze_keyword_for_newarticle( const std::string& html ) {}
 
         // 書き込み時のリファラ
         virtual std::string get_write_referer(){ return url_boardbase(); }

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -327,7 +327,7 @@ namespace DBTREE
         // 板のホストを指定してクッキーのやり取り
         virtual std::string cookie_for_request() const;
         void set_list_cookies( const std::list< std::string >& list_cookies );
-        void delete_cookies_for_request();
+        void delete_cookies();
 
         // 書き込み時に必要なキーワード( hana=mogera や suka=pontan など )
         // 書き込み時のメッセージに付加する

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -232,11 +232,11 @@ namespace DBTREE
         void send_update_board();
 
         // クッキー
-        virtual std::string get_cookie() const { return {}; }
-        virtual void set_cookie( const std::string& cookie ) {}
+        virtual std::string get_hap() const { return {}; }
+        virtual void set_hap( const std::string& hap ){}
 
         // クッキーの更新 (クッキーをセットした時に実行)
-        virtual void update_cookie() {}
+        virtual void update_hap(){}
 
       public:
 

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -326,7 +326,7 @@ namespace DBTREE
 
         // 板のホストを指定してクッキーのやり取り
         virtual std::string cookie_for_request() const;
-        void set_list_cookies_for_request( const std::list< std::string >& list_cookies );
+        void set_list_cookies( const std::list< std::string >& list_cookies );
         void delete_cookies_for_request();
 
         // 書き込み時に必要なキーワード( hana=mogera や suka=pontan など )

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -412,6 +412,9 @@ namespace DBTREE
         // article クラスのポインタ取得
         ArticleBase* get_article_fromURL( const std::string& url );
 
+        // フロントページのダウンロード
+        virtual void download_front() {}
+
         // subject.txt ダウンロード
         // url_update_view : CORE::core_set_command( "update_board" ) を送信するビューのアドレス
         // read_from_cache : まだスレ一覧を開いていないときにキャッシュのsubject.txtを読み込む

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -325,7 +325,9 @@ namespace DBTREE
         virtual std::string get_unicode();
 
         // 板のホストを指定してクッキーのやり取り
+        std::string cookie_by_host() const;
         virtual std::string cookie_for_request() const;
+        virtual std::string cookie_for_post() const;
         void set_list_cookies( const std::list< std::string >& list_cookies );
         void delete_cookies();
 

--- a/src/dbtree/frontloader.cpp
+++ b/src/dbtree/frontloader.cpp
@@ -20,7 +20,6 @@ FrontLoader::FrontLoader( const std::string& url_boadbase )
     : SKELETON::TextLoader()
     , m_url_boadbase( url_boadbase )
 {
-    set_date_modified( DBTREE::board_date_modified( m_url_boadbase ) );
 }
 
 
@@ -54,7 +53,9 @@ void FrontLoader::create_loaderdata( JDLIB::LOADERDATA& data )
 void FrontLoader::parse_data()
 {
     // フロントページからキーワードを解析して登録する
-    DBTREE::board_analyze_keyword_for_newarticle( m_url_boadbase, get_data() );
+    if( ! get_data().empty() ) {
+        DBTREE::board_analyze_keyword_for_newarticle( m_url_boadbase, get_data() );
+    }
 }
 
 

--- a/src/dbtree/frontloader.cpp
+++ b/src/dbtree/frontloader.cpp
@@ -53,7 +53,8 @@ void FrontLoader::create_loaderdata( JDLIB::LOADERDATA& data )
 // ロード後に呼び出される
 void FrontLoader::parse_data()
 {
-    // TODO: ダウンロードしたHTMLをキーワード解析関数に渡す
+    // フロントページからキーワードを解析して登録する
+    DBTREE::board_analyze_keyword_for_newarticle( m_url_boadbase, get_data() );
 }
 
 

--- a/src/dbtree/frontloader.cpp
+++ b/src/dbtree/frontloader.cpp
@@ -1,0 +1,63 @@
+// ライセンス: GPL2
+
+//#define _DEBUG
+#include "jddebug.h"
+
+#include "frontloader.h"
+#include "interface.h"
+
+#include "jdlib/loaderdata.h"
+
+#include "config/globalconf.h"
+
+#include "cache.h"
+
+
+using namespace DBTREE;
+
+
+FrontLoader::FrontLoader( const std::string& url_boadbase )
+    : SKELETON::TextLoader()
+    , m_url_boadbase( url_boadbase )
+{
+    set_date_modified( DBTREE::board_date_modified( m_url_boadbase ) );
+}
+
+
+std::string FrontLoader::get_charset()
+{
+    return DBTREE::board_charset( m_url_boadbase );
+}
+
+
+// ロード用データ作成
+void FrontLoader::create_loaderdata( JDLIB::LOADERDATA& data )
+{
+    // 移転処理
+    std::string url_boardbase = DBTREE::url_boardbase( m_url_boadbase );
+    if( m_url_boadbase != url_boardbase ) m_url_boadbase = url_boardbase;
+
+    data.url = get_url();
+    data.agent = DBTREE::get_agent( m_url_boadbase );
+    data.host_proxy = DBTREE::get_proxy_host( m_url_boadbase );
+    data.port_proxy = DBTREE::get_proxy_port( m_url_boadbase );
+    data.basicauth_proxy = DBTREE::get_proxy_basicauth( m_url_boadbase );
+    data.size_buf = CONFIG::get_loader_bufsize();
+    data.timeout = CONFIG::get_loader_timeout();
+    if( ! get_date_modified().empty() ) data.modified = get_date_modified();
+    data.basicauth = DBTREE::board_basicauth( m_url_boadbase );
+    data.cookie_for_request = DBTREE::board_cookie_for_request( m_url_boadbase );
+}
+
+
+// ロード後に呼び出される
+void FrontLoader::parse_data()
+{
+    // TODO: ダウンロードしたHTMLをキーワード解析関数に渡す
+}
+
+
+void FrontLoader::receive_cookies()
+{
+    DBTREE::board_set_list_cookies( m_url_boadbase, SKELETON::Loadable::cookies() );
+}

--- a/src/dbtree/frontloader.h
+++ b/src/dbtree/frontloader.h
@@ -1,0 +1,47 @@
+// ライセンス: GPL2
+//
+// 板のフロントページのローダー
+//
+
+#ifndef JDIM_FRONTLOADER_H
+#define JDIM_FRONTLOADER_H
+
+#include "skeleton/textloader.h"
+
+#include <string>
+
+namespace JDLIB
+{
+    class LOADERDATA;
+}
+
+namespace DBTREE
+{
+    class FrontLoader : public SKELETON::TextLoader
+    {
+        std::string m_url_boadbase;
+
+      public:
+
+        FrontLoader( const std::string& url_boardbase );
+        ~FrontLoader() = default;
+
+      protected:
+
+        std::string get_url() override { return m_url_boadbase; }
+        std::string get_path() override { return {}; } // キャッシュには保存しない
+        std::string get_charset() override;
+
+        // ロード用データ作成
+        void create_loaderdata( JDLIB::LOADERDATA& data ) override;
+
+        // ロード後に呼び出される
+        void parse_data() override;
+
+      private:
+
+        void receive_cookies() override;
+    };
+}
+
+#endif // JDIM_FRONTLOADER_H

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -309,9 +309,9 @@ void DBTREE::board_set_list_cookies( const std::string& url, const std::list< st
     DBTREE::get_board( url )->set_list_cookies( list_cookies );
 }
 
-void DBTREE::board_delete_cookies_for_request( const std::string& url )
+void DBTREE::board_delete_cookies( const std::string& url )
 {
-    DBTREE::get_board( url )->delete_cookies_for_request();
+    DBTREE::get_board( url )->delete_cookies();
 }
 
 std::string DBTREE::board_keyword_for_write( const std::string& url )

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -344,6 +344,24 @@ void DBTREE::board_analyze_keyword_for_write( const std::string& url, const std:
 }
 
 
+std::string DBTREE::board_keyword_for_newarticle( const std::string& url )
+{
+    return DBTREE::get_board( url )->get_keyword_for_newarticle();
+}
+
+
+void DBTREE::board_set_keyword_for_newarticle( const std::string& url, const std::string& keyword )
+{
+    DBTREE::get_board( url )->set_keyword_for_newarticle( keyword );
+}
+
+
+void DBTREE::board_analyze_keyword_for_newarticle( const std::string& url, const std::string& html )
+{
+    DBTREE::get_board( url )->analyze_keyword_for_newarticle( html );
+}
+
+
 std::string DBTREE::board_basicauth( const std::string& url )
 {
     return DBTREE::get_board( url )->get_basicauth();

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -304,9 +304,9 @@ std::string DBTREE::board_cookie_for_request( const std::string& url )
 }
 
 
-void DBTREE::board_set_list_cookies_for_request( const std::string& url, const std::list< std::string>& list_cookies )
+void DBTREE::board_set_list_cookies( const std::string& url, const std::list< std::string>& list_cookies )
 {
-    DBTREE::get_board( url )->set_list_cookies_for_request( list_cookies );
+    DBTREE::get_board( url )->set_list_cookies( list_cookies );
 }
 
 void DBTREE::board_delete_cookies_for_request( const std::string& url )

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -298,9 +298,21 @@ std::string DBTREE::board_charset( const std::string& url )
 }
 
 
+std::string DBTREE::board_cookie_by_host( const std::string& url )
+{
+    return DBTREE::get_board( url )->cookie_by_host();
+}
+
+
 std::string DBTREE::board_cookie_for_request( const std::string& url )
 {
     return DBTREE::get_board( url )->cookie_for_request();
+}
+
+
+std::string DBTREE::board_cookie_for_post( const std::string& url )
+{
+    return DBTREE::get_board( url )->cookie_for_post();
 }
 
 

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -398,6 +398,12 @@ void DBTREE::board_save_info( const std::string& url )
 }
 
 
+void DBTREE::board_download_front( const std::string& url )
+{
+    DBTREE::get_board( url )->download_front();
+}
+
+
 void DBTREE::board_download_subject( const std::string& url, const std::string& url_update_view )
 {
     DBTREE::get_board( url )->download_subject( url_update_view, false );

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -105,7 +105,7 @@ namespace DBTREE
     std::string board_charset( const std::string& url );
     std::string board_cookie_for_request( const std::string& url );
     void board_set_list_cookies( const std::string& url, const std::list< std::string>& list_cookies );
-    void board_delete_cookies_for_request( const std::string& url );
+    void board_delete_cookies( const std::string& url );
     std::string board_keyword_for_write( const std::string& url );
     void board_set_keyword_for_write( const std::string& url, const std::string& keyword );
     void board_analyze_keyword_for_write( const std::string& url, const std::string& html );

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -104,7 +104,7 @@ namespace DBTREE
     std::string board_subjecttxt( const std::string& url );
     std::string board_charset( const std::string& url );
     std::string board_cookie_for_request( const std::string& url );
-    void board_set_list_cookies_for_request( const std::string& url, const std::list< std::string>& list_cookies );
+    void board_set_list_cookies( const std::string& url, const std::list< std::string>& list_cookies );
     void board_delete_cookies_for_request( const std::string& url );
     std::string board_keyword_for_write( const std::string& url );
     void board_set_keyword_for_write( const std::string& url, const std::string& keyword );

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -103,7 +103,9 @@ namespace DBTREE
     std::string board_name( const std::string& url );
     std::string board_subjecttxt( const std::string& url );
     std::string board_charset( const std::string& url );
+    std::string board_cookie_by_host( const std::string& url );
     std::string board_cookie_for_request( const std::string& url );
+    std::string board_cookie_for_post( const std::string& url );
     void board_set_list_cookies( const std::string& url, const std::list< std::string>& list_cookies );
     void board_delete_cookies( const std::string& url );
     std::string board_keyword_for_write( const std::string& url );

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -111,6 +111,9 @@ namespace DBTREE
     std::string board_keyword_for_write( const std::string& url );
     void board_set_keyword_for_write( const std::string& url, const std::string& keyword );
     void board_analyze_keyword_for_write( const std::string& url, const std::string& html );
+    std::string board_keyword_for_newarticle( const std::string& url );
+    void board_set_keyword_for_newarticle( const std::string& url, const std::string& keyword );
+    void board_analyze_keyword_for_newarticle( const std::string& url, const std::string& html );
     std::string board_basicauth( const std::string& url );
     std::string board_ext( const std::string& url );
     int board_status( const std::string& url );

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -120,6 +120,7 @@ namespace DBTREE
     int board_code( const std::string& url );
     std::string board_str_code( const std::string& url );
     void board_save_info( const std::string& url );
+    void board_download_front( const std::string& url );
     void board_download_subject( const std::string& url, const std::string& url_update_view );
     void board_read_subject_from_cache( const std::string& url );
     bool board_is_loading( const std::string& url );

--- a/src/dbtree/nodetree2ch.cpp
+++ b/src/dbtree/nodetree2ch.cpp
@@ -189,10 +189,7 @@ void NodeTree2ch::create_loaderdata( JDLIB::LOADERDATA& data )
     data.host_proxy = DBTREE::get_proxy_host( get_url() );
     data.port_proxy = DBTREE::get_proxy_port( get_url() );
     data.basicauth_proxy = DBTREE::get_proxy_basicauth( get_url() );
-    // プロキシの読み込み用設定がonのときスレ読み込みではcookieを送信しない
-    if( ! CONFIG::get_use_proxy_for2ch() ) {
-        data.cookie_for_request = DBTREE::board_cookie_for_request( get_url() );
-    }
+    data.cookie_for_request = DBTREE::board_cookie_for_request( get_url() );
 
     data.size_buf = CONFIG::get_loader_bufsize();
     data.timeout = CONFIG::get_loader_timeout();

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -1406,7 +1406,7 @@ void NodeTreeBase::receive_finish()
     ) {
         CACHE::set_filemtime( CACHE::path_dat( m_url ), get_time_modified() );
         // クッキーのセット
-        DBTREE::board_set_list_cookies_for_request( m_url, SKELETON::Loadable::cookies() );
+        DBTREE::board_set_list_cookies( m_url, SKELETON::Loadable::cookies() );
     }
 
 

--- a/src/dbtree/ruleloader.cpp
+++ b/src/dbtree/ruleloader.cpp
@@ -88,5 +88,5 @@ void RuleLoader::parse_data()
 
 void RuleLoader::receive_cookies()
 {
-    DBTREE::board_set_list_cookies_for_request( m_url_boadbase, SKELETON::Loadable::cookies() );
+    DBTREE::board_set_list_cookies( m_url_boadbase, SKELETON::Loadable::cookies() );
 }

--- a/src/dbtree/settingloader.cpp
+++ b/src/dbtree/settingloader.cpp
@@ -104,5 +104,5 @@ void SettingLoader::parse_data()
 
 void SettingLoader::receive_cookies()
 {
-    DBTREE::board_set_list_cookies_for_request( m_url_boadbase, SKELETON::Loadable::cookies() );
+    DBTREE::board_set_list_cookies( m_url_boadbase, SKELETON::Loadable::cookies() );
 }

--- a/src/message/messageview.cpp
+++ b/src/message/messageview.cpp
@@ -153,6 +153,9 @@ void MessageViewMain::reload()
 
     // メインウィンドウのタイトルに表示する文字
     set_title( "[ 新スレ作成 ] " + DBTREE::article_subject( get_url() ) );
+
+    // 板のフロントページをダウンロードしてスレ立てに使うキーワードを更新する
+    DBTREE::board_download_front( get_url() );
 }
 
 

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -168,7 +168,7 @@ void Post::post_msg()
     data.basicauth_proxy = DBTREE::get_proxy_basicauth_w( m_url );
     data.size_buf = CONFIG::get_loader_bufsize();
     data.timeout = CONFIG::get_loader_timeout_post();
-    data.cookie_for_request = DBTREE::board_cookie_for_request( m_url );
+    data.cookie_for_request = DBTREE::board_cookie_for_post( m_url );
     data.basicauth = DBTREE::board_basicauth( m_url );
 
 #ifdef _DEBUG

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -360,7 +360,7 @@ void Post::receive_finish()
 
     // クッキーのセット
     const bool empty_cookies = DBTREE::board_cookie_for_request( m_url ).empty();
-    if( list_cookies.size() ) DBTREE::board_set_list_cookies_for_request( m_url, list_cookies );
+    if( list_cookies.size() ) DBTREE::board_set_list_cookies( m_url, list_cookies );
 
     // 成功
     if( title.find( "書きこみました" ) != std::string::npos

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -373,6 +373,10 @@ void Post::receive_finish()
 #endif        
 
         DBTREE::article_update_writetime( m_url );
+        if( m_new_article ) {
+            // 板のフロントページをダウンロードしてスレ立てに使うキーワードを更新する
+            DBTREE::board_download_front( m_url );
+        }
         emit_sigfin();
         return;
     }

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -407,11 +407,8 @@ void Post::receive_finish()
             if( mdiag.get_chkbutton().get_active() ) CONFIG::set_always_write_ok( true );
         }
 
-        // 書き込み用キーワード( hana=mogera や suka=pontan など )をセット
-        DBTREE::board_analyze_keyword_for_write( m_url, m_return_html );
-
         // 現在のメッセージにキーワードが付加されていない時は付け加える
-        const std::string keyword = DBTREE::board_keyword_for_write( m_url );
+        const std::string keyword = update_keyword( m_url, m_return_html, m_new_article );
         if( ! keyword.empty() && m_msg.find( keyword ) == std::string::npos ) m_msg += "&" + keyword;
 
         ++m_count; // 永久ループ防止
@@ -424,11 +421,8 @@ void Post::receive_finish()
     else if( m_count < 1 // 永久ループ防止
              && ! m_subbbs && conf.find( "書き込み確認" ) != std::string::npos ){
 
-        // 書き込み用キーワード( hana=mogera や suka=pontan など )をセット
-        DBTREE::board_analyze_keyword_for_write( m_url, m_return_html );
-
         // 現在のメッセージにキーワードが付加されていない時は付け加える
-        const std::string keyword = DBTREE::board_keyword_for_write( m_url );
+        const std::string keyword = update_keyword( m_url, m_return_html, m_new_article );
         if( ! keyword.empty() && m_msg.find( keyword ) == std::string::npos ) m_msg += "&" + keyword;
 
         // subbbs.cgi にポスト先を変更してもう一回ポスト
@@ -449,4 +443,24 @@ void Post::receive_finish()
 
     set_code( HTTP_ERR );
     emit_sigfin();
+}
+
+
+//
+// キーワードを更新する
+//
+std::string Post::update_keyword( const std::string& url, const std::string& html, bool new_article )
+{
+    if( new_article ) {
+        // スレ立て用キーワードをセット
+        DBTREE::board_analyze_keyword_for_newarticle( url, html );
+
+        return DBTREE::board_keyword_for_newarticle( url );
+    }
+    else {
+        // 書き込み用キーワード( hana=mogera や suka=pontan など )をセット
+        DBTREE::board_analyze_keyword_for_write( url, html );
+
+        return DBTREE::board_keyword_for_write( url );
+    }
 }

--- a/src/message/post.cpp
+++ b/src/message/post.cpp
@@ -24,6 +24,43 @@
 #include <cstring>
 
 
+namespace {
+
+// PostStrategyの実装
+// newするのは大げさなので静的変数を定義した
+
+// 書き込み用のインターフェース
+struct WriteStrategy : public MESSAGE::PostStrategy
+{
+    std::string url_bbscgi( const std::string& url ) override { return DBTREE::url_bbscgi( url ); }
+    std::string url_subbbscgi( const std::string& url ) override { return DBTREE::url_subbbscgi( url ); }
+
+    void analyze_keyword( const std::string& url, const std::string& html ) override
+    {
+        DBTREE::board_analyze_keyword_for_write( url, html );
+    }
+    std::string get_keyword( const std::string& url ) override { return DBTREE::board_keyword_for_write( url ); }
+
+} s_write_strategy;
+
+
+// スレ立て用のインターフェース
+struct NewArticleStrategy : public MESSAGE::PostStrategy
+{
+    std::string url_bbscgi( const std::string& url ) override { return DBTREE::url_bbscgi_new( url ); }
+    std::string url_subbbscgi( const std::string& url ) override { return DBTREE::url_subbbscgi_new( url ); }
+
+    void analyze_keyword( const std::string& url, const std::string& html ) override
+    {
+        DBTREE::board_analyze_keyword_for_newarticle( url, html );
+    }
+    std::string get_keyword( const std::string& url ) override { return DBTREE::board_keyword_for_newarticle( url ); }
+
+} s_new_article_strategy;
+
+} // namespace
+
+
 using namespace MESSAGE;
 
 enum
@@ -44,6 +81,9 @@ Post::Post( Gtk::Widget* parent, const std::string& url, const std::string& msg,
 #ifdef _DEBUG
     std::cout << "Post::Post " << m_url << std::endl;
 #endif
+
+    if( new_article ) m_post_strategy = &s_new_article_strategy;
+    else m_post_strategy = &s_write_strategy;
 
     clear();
 }
@@ -143,17 +183,8 @@ void Post::post_msg()
 
     JDLIB::LOADERDATA data;
 
-    // 通常書き込み
-    if( ! m_new_article ){
-        if( ! m_subbbs ) data.url = DBTREE::url_bbscgi( m_url );  // 1回目の投稿先
-        else data.url = DBTREE::url_subbbscgi( m_url ); // 2回目の投稿先
-    }
-
-    // 新スレ作成
-    else{
-        if( ! m_subbbs ) data.url = DBTREE::url_bbscgi_new( m_url );  // 1回目の投稿先
-        else data.url = DBTREE::url_subbbscgi_new( m_url ); // 2回目の投稿先
-    }
+    if( ! m_subbbs ) data.url = m_post_strategy->url_bbscgi( m_url ); // 1回目の投稿先
+    else data.url = m_post_strategy->url_subbbscgi( m_url ); // 2回目の投稿先
 
     // Content-Type (2009/02/18に報告された"したらば"に書き込めない問題で追加)
     // http://www.asahi-net.or.jp/~sd5a-ucd/rec-html401j/interact/forms.html#h-17.13.4.1
@@ -411,8 +442,11 @@ void Post::receive_finish()
             if( mdiag.get_chkbutton().get_active() ) CONFIG::set_always_write_ok( true );
         }
 
+        // キーワードを解析してセット
+        m_post_strategy->analyze_keyword( m_url, m_return_html );
+
         // 現在のメッセージにキーワードが付加されていない時は付け加える
-        const std::string keyword = update_keyword( m_url, m_return_html, m_new_article );
+        const std::string keyword = m_post_strategy->get_keyword( m_url );
         if( ! keyword.empty() && m_msg.find( keyword ) == std::string::npos ) m_msg += "&" + keyword;
 
         ++m_count; // 永久ループ防止
@@ -425,8 +459,11 @@ void Post::receive_finish()
     else if( m_count < 1 // 永久ループ防止
              && ! m_subbbs && conf.find( "書き込み確認" ) != std::string::npos ){
 
+        // キーワードを解析してセット
+        m_post_strategy->analyze_keyword( m_url, m_return_html );
+
         // 現在のメッセージにキーワードが付加されていない時は付け加える
-        const std::string keyword = update_keyword( m_url, m_return_html, m_new_article );
+        const std::string keyword = m_post_strategy->get_keyword( m_url );
         if( ! keyword.empty() && m_msg.find( keyword ) == std::string::npos ) m_msg += "&" + keyword;
 
         // subbbs.cgi にポスト先を変更してもう一回ポスト
@@ -447,24 +484,4 @@ void Post::receive_finish()
 
     set_code( HTTP_ERR );
     emit_sigfin();
-}
-
-
-//
-// キーワードを更新する
-//
-std::string Post::update_keyword( const std::string& url, const std::string& html, bool new_article )
-{
-    if( new_article ) {
-        // スレ立て用キーワードをセット
-        DBTREE::board_analyze_keyword_for_newarticle( url, html );
-
-        return DBTREE::board_keyword_for_newarticle( url );
-    }
-    else {
-        // 書き込み用キーワード( hana=mogera や suka=pontan など )をセット
-        DBTREE::board_analyze_keyword_for_write( url, html );
-
-        return DBTREE::board_keyword_for_write( url );
-    }
 }

--- a/src/message/post.h
+++ b/src/message/post.h
@@ -20,6 +20,16 @@ namespace SKELETON
 
 namespace MESSAGE
 {
+    // 投稿の種類で異なるインターフェース部分を抽象クラスにしてStrategyパターンを使う
+    // 実行時にコンストラクタでインターフェースを選択する
+    struct PostStrategy
+    {
+        virtual std::string url_bbscgi( const std::string& url ) = 0; // 1回目の投稿先
+        virtual std::string url_subbbscgi( const std::string& url ) = 0; // 2回目の投稿先
+        virtual void analyze_keyword( const std::string& url, const std::string& html ) = 0; // キーワードを解析
+        virtual std::string get_keyword( const std::string& url ) = 0; // キーワードをゲット
+    };
+
     class Post : public SKELETON::Loadable
     {
         // ポスト終了シグナル
@@ -42,6 +52,8 @@ namespace MESSAGE
         // 書き込んでいますのダイアログ
         SKELETON::MsgDiag* m_writingdiag;
 
+        PostStrategy* m_post_strategy;
+
       public:
 
         Post( Gtk::Widget* parent, const std::string& url, const std::string& msg, bool new_article );
@@ -63,9 +75,6 @@ namespace MESSAGE
 
         void receive_data( const char* data, size_t size ) override;
         void receive_finish() override;
-
-        // キーワードの更新
-        static std::string update_keyword( const std::string& url, const std::string& html, bool new_article );
     };
     
 }

--- a/src/message/post.h
+++ b/src/message/post.h
@@ -63,6 +63,9 @@ namespace MESSAGE
 
         void receive_data( const char* data, size_t size ) override;
         void receive_finish() override;
+
+        // キーワードの更新
+        static std::string update_keyword( const std::string& url, const std::string& html, bool new_article );
     };
     
 }

--- a/src/proxypref.h
+++ b/src/proxypref.h
@@ -14,6 +14,9 @@
 
 namespace CORE
 {
+    constexpr const char kSendCookieTooltip[] = "JDimからプロキシへサイトのクッキーを送信します。\n"
+                                                "プロキシのクッキー処理にあわせて設定してください。";
+
     class ProxyFrame : public Gtk::Frame
     {
         Gtk::VBox m_vbox;
@@ -22,17 +25,22 @@ namespace CORE
       public:
 
         Gtk::CheckButton ckbt;
+        Gtk::CheckButton send_cookie_check;
         SKELETON::LabelEntry entry_host;
         SKELETON::LabelEntry entry_port;
 
-        ProxyFrame( const std::string& title, const Glib::ustring& ckbt_label,
+        ProxyFrame( const std::string& title, const Glib::ustring& ckbt_label, const Glib::ustring& send_label,
                     const Glib::ustring& host_label, const Glib::ustring& port_label )
             : ckbt( ckbt_label, true )
-            , entry_host( true, host_label )
+            , send_cookie_check( send_label, true )
+            , entry_host( true, host_label)
             , entry_port( true, port_label )
         {
+            send_cookie_check.set_tooltip_text( kSendCookieTooltip );
+
             m_hbox.set_spacing( 8 );
             m_hbox.pack_start( ckbt, Gtk::PACK_SHRINK );
+            m_hbox.pack_start( send_cookie_check, Gtk::PACK_SHRINK );
             m_hbox.pack_start( entry_host );
             m_hbox.pack_start( entry_port, Gtk::PACK_SHRINK );
 
@@ -64,16 +72,19 @@ namespace CORE
         {
             // 2ch
             CONFIG::set_use_proxy_for2ch( m_frame_2ch.ckbt.get_active() );
+            CONFIG::set_send_cookie_to_proxy_for2ch( m_frame_2ch.send_cookie_check.get_active() );
             CONFIG::set_proxy_for2ch( MISC::remove_space( m_frame_2ch.entry_host.get_text() ) );
             CONFIG::set_proxy_port_for2ch( atoi( m_frame_2ch.entry_port.get_text().c_str() ) );
 
             // 2ch書き込み用
             CONFIG::set_use_proxy_for2ch_w( m_frame_2ch_w.ckbt.get_active() );
+            CONFIG::set_send_cookie_to_proxy_for2ch_w( m_frame_2ch_w.send_cookie_check.get_active() );
             CONFIG::set_proxy_for2ch_w( MISC::remove_space( m_frame_2ch_w.entry_host.get_text() ) );
             CONFIG::set_proxy_port_for2ch_w( atoi( m_frame_2ch_w.entry_port.get_text().c_str() ) );
 
             // 一般
             CONFIG::set_use_proxy_for_data( m_frame_data.ckbt.get_active() );
+            CONFIG::set_send_cookie_to_proxy_for_data( m_frame_data.send_cookie_check.get_active() );
             CONFIG::set_proxy_for_data( MISC::remove_space( m_frame_data.entry_host.get_text() ) );
             CONFIG::set_proxy_port_for_data( atoi( m_frame_data.entry_port.get_text().c_str() ) );
         }
@@ -83,15 +94,18 @@ namespace CORE
         ProxyPref( Gtk::Window* parent, const std::string& url )
             : SKELETON::PrefDiag( parent, url )
             , m_label( "認証を行う場合はホスト名を「ユーザID:パスワード@ホスト名」としてください。" )
-            , m_frame_2ch( "2ch読み込み用", "使用する(_U)", "ホスト名(_H)： ", "ポート番号(_P)： " )
-            , m_frame_2ch_w( "2ch書き込み用", "使用する(_S)", "ホスト名(_N)： ", "ポート番号(_R)： " )
-            , m_frame_data( "その他のサーバ用(板一覧、外部板、画像など)", "使用する(_E)", "ホスト名(_A)： ",
-                            "ポート番号(_T)： " )
+            , m_frame_2ch( "2ch読み込み用", "使用する(_U)", "クッキーを送る(_I)",
+                           "ホスト名(_H)： ", "ポート番号(_P)： " )
+            , m_frame_2ch_w( "2ch書き込み用", "使用する(_S)", "クッキーを送る(_J)",
+                             "ホスト名(_N)： ", "ポート番号(_R)： " )
+            , m_frame_data( "その他のサーバ用(板一覧、外部板、画像など)", "使用する(_E)", "クッキーを送る(_K)",
+                            "ホスト名(_A)： ", "ポート番号(_T)： " )
         {
             std::string host;
 
             // 2ch用
             m_frame_2ch.ckbt.set_active( CONFIG::get_use_proxy_for2ch() );
+            m_frame_2ch.send_cookie_check.set_active( CONFIG::get_send_cookie_to_proxy_for2ch() );
             if( CONFIG::get_proxy_basicauth_for2ch().empty() ) host = CONFIG::get_proxy_for2ch();
             else host = CONFIG::get_proxy_basicauth_for2ch() + "@" + CONFIG::get_proxy_for2ch();
             m_frame_2ch.entry_host.set_text( host );
@@ -102,6 +116,7 @@ namespace CORE
 
             // 2ch書き込み用
             m_frame_2ch_w.ckbt.set_active( CONFIG::get_use_proxy_for2ch_w() );
+            m_frame_2ch_w.send_cookie_check.set_active( CONFIG::get_send_cookie_to_proxy_for2ch_w() );
             if( CONFIG::get_proxy_basicauth_for2ch_w().empty() ) host = CONFIG::get_proxy_for2ch_w();
             else host = CONFIG::get_proxy_basicauth_for2ch_w() + "@" + CONFIG::get_proxy_for2ch_w();
             m_frame_2ch_w.entry_host.set_text( host );
@@ -112,6 +127,7 @@ namespace CORE
 
             // 一般用
             m_frame_data.ckbt.set_active( CONFIG::get_use_proxy_for_data() );
+            m_frame_data.send_cookie_check.set_active( CONFIG::get_send_cookie_to_proxy_for_data() );
             if( CONFIG::get_proxy_basicauth_for_data().empty() ) host = CONFIG::get_proxy_for_data();
             else host = CONFIG::get_proxy_basicauth_for_data() + "@" + CONFIG::get_proxy_for_data();
             m_frame_data.entry_host.set_text( host );

--- a/src/proxypref.h
+++ b/src/proxypref.h
@@ -25,8 +25,11 @@ namespace CORE
         SKELETON::LabelEntry entry_host;
         SKELETON::LabelEntry entry_port;
 
-        ProxyFrame( const std::string& title, const Glib::ustring& ckbt_label, const Glib::ustring& host_label, const Glib::ustring& port_label )
-        : ckbt( ckbt_label, true ), entry_host( true, host_label), entry_port( true, port_label ) 
+        ProxyFrame( const std::string& title, const Glib::ustring& ckbt_label,
+                    const Glib::ustring& host_label, const Glib::ustring& port_label )
+            : ckbt( ckbt_label, true )
+            , entry_host( true, host_label )
+            , entry_port( true, port_label )
         {
             m_hbox.set_spacing( 8 );
             m_hbox.pack_start( ckbt, Gtk::PACK_SHRINK );
@@ -60,20 +63,17 @@ namespace CORE
         void slot_ok_clicked() override
         {
             // 2ch
-            if( m_frame_2ch.ckbt.get_active() ) CONFIG::set_use_proxy_for2ch( true );
-            else CONFIG::set_use_proxy_for2ch( false );
+            CONFIG::set_use_proxy_for2ch( m_frame_2ch.ckbt.get_active() );
             CONFIG::set_proxy_for2ch( MISC::remove_space( m_frame_2ch.entry_host.get_text() ) );
             CONFIG::set_proxy_port_for2ch( atoi( m_frame_2ch.entry_port.get_text().c_str() ) );
 
             // 2ch書き込み用
-            if( m_frame_2ch_w.ckbt.get_active() ) CONFIG::set_use_proxy_for2ch_w( true );
-            else CONFIG::set_use_proxy_for2ch_w( false );
+            CONFIG::set_use_proxy_for2ch_w( m_frame_2ch_w.ckbt.get_active() );
             CONFIG::set_proxy_for2ch_w( MISC::remove_space( m_frame_2ch_w.entry_host.get_text() ) );
             CONFIG::set_proxy_port_for2ch_w( atoi( m_frame_2ch_w.entry_port.get_text().c_str() ) );
 
             // 一般
-            if( m_frame_data.ckbt.get_active() ) CONFIG::set_use_proxy_for_data( true );
-            else CONFIG::set_use_proxy_for_data( false );
+            CONFIG::set_use_proxy_for_data( m_frame_data.ckbt.get_active() );
             CONFIG::set_proxy_for_data( MISC::remove_space( m_frame_data.entry_host.get_text() ) );
             CONFIG::set_proxy_port_for_data( atoi( m_frame_data.entry_port.get_text().c_str() ) );
         }
@@ -81,17 +81,17 @@ namespace CORE
       public:
 
         ProxyPref( Gtk::Window* parent, const std::string& url )
-        : SKELETON::PrefDiag( parent, url ),
-        m_label( "認証を行う場合はホスト名を「ユーザID:パスワード@ホスト名」としてください。" ),
-        m_frame_2ch( "2ch読み込み用", "使用する(_U)", "ホスト名(_H)： ", "ポート番号(_P)： " ), 
-        m_frame_2ch_w( "2ch書き込み用", "使用する(_S)", "ホスト名(_N)： ", "ポート番号(_R)： " ),
-        m_frame_data( "その他のサーバ用(板一覧、外部板、画像など)", "使用する(_E)", "ホスト名(_A)： ", "ポート番号(_T)： " )
+            : SKELETON::PrefDiag( parent, url )
+            , m_label( "認証を行う場合はホスト名を「ユーザID:パスワード@ホスト名」としてください。" )
+            , m_frame_2ch( "2ch読み込み用", "使用する(_U)", "ホスト名(_H)： ", "ポート番号(_P)： " )
+            , m_frame_2ch_w( "2ch書き込み用", "使用する(_S)", "ホスト名(_N)： ", "ポート番号(_R)： " )
+            , m_frame_data( "その他のサーバ用(板一覧、外部板、画像など)", "使用する(_E)", "ホスト名(_A)： ",
+                            "ポート番号(_T)： " )
         {
             std::string host;
 
             // 2ch用
-            if( CONFIG::get_use_proxy_for2ch() ) m_frame_2ch.ckbt.set_active( true );
-            else m_frame_2ch.ckbt.set_active( false );
+            m_frame_2ch.ckbt.set_active( CONFIG::get_use_proxy_for2ch() );
             if( CONFIG::get_proxy_basicauth_for2ch().empty() ) host = CONFIG::get_proxy_for2ch();
             else host = CONFIG::get_proxy_basicauth_for2ch() + "@" + CONFIG::get_proxy_for2ch();
             m_frame_2ch.entry_host.set_text( host );
@@ -101,8 +101,7 @@ namespace CORE
             set_activate_entry( m_frame_2ch.entry_port );
 
             // 2ch書き込み用
-            if( CONFIG::get_use_proxy_for2ch_w() ) m_frame_2ch_w.ckbt.set_active( true );
-            else m_frame_2ch_w.ckbt.set_active( false );
+            m_frame_2ch_w.ckbt.set_active( CONFIG::get_use_proxy_for2ch_w() );
             if( CONFIG::get_proxy_basicauth_for2ch_w().empty() ) host = CONFIG::get_proxy_for2ch_w();
             else host = CONFIG::get_proxy_basicauth_for2ch_w() + "@" + CONFIG::get_proxy_for2ch_w();
             m_frame_2ch_w.entry_host.set_text( host );
@@ -112,8 +111,7 @@ namespace CORE
             set_activate_entry( m_frame_2ch_w.entry_port );
 
             // 一般用
-            if( CONFIG::get_use_proxy_for_data() ) m_frame_data.ckbt.set_active( true );
-            else m_frame_data.ckbt.set_active( false );
+            m_frame_data.ckbt.set_active( CONFIG::get_use_proxy_for_data() );
             if( CONFIG::get_proxy_basicauth_for_data().empty() ) host = CONFIG::get_proxy_for_data();
             else host = CONFIG::get_proxy_basicauth_for_data() + "@" + CONFIG::get_proxy_for_data();
             m_frame_data.entry_host.set_text( host );


### PR DESCRIPTION
**このPRはアイデア検証用でありマージしません。**

既存の書き込み用キーワードの処理を新しい実装に入れ換えます。
5chのスレ立てテストに利用してください。
スレ立ては規制や制限の影響を避けるため流れが速い板をおすすめします。

### 変更点

- プロキシ設定にチェック項目「クッキーを送る」を追加します。
  チェックを入れるとJDimからプロキシへサイトのクッキーを送信します。
  プロキシのクッキー処理にあわせて設定してください。

  [![thumb][]][screenshot]

- 特定のサイト(5ch)の板ビューでスレ立ての編集画面を開いたときに書き込み用キーワードを取得するようになります。
  取得したキーワードはスレ立てのリクエストに追加されて消費されます。

[thumb]: https://i.imgur.com/qplOu2el.png
[screenshot]: https://i.imgur.com/qplOu2e.png

### パッチの適応方法

#### curl と patch コマンドを使う場合
※ git pullなどでmasterブランチを更新してから行うことを推奨します。

```
make clean
git chechout master
git pull
curl -L https://github.com/ma8ma/JDim/pull/40.patch | patch -p1
autoreconf -i && ./configure
make -j2

# パッチの削除
make clean
git reset --hard master
rm src/dbtree/frontloader.*
autoreconf -i && ./configure
make -j2
```

#### [hub コマンド][hub]を使う場合

```
make clean
hub checkout https://github.com/ma8ma/JDim/pull/40
autoreconf -i && ./configure
make -j2

# パッチの削除
make clean
git checkout master
git branch -D idea-cookie-manager
autoreconf -i && ./configure
make -j2
```

[hub]: https://hub.github.com/
