### PR TITLE
[IDEA] スレビューのフォントを修正する (GTK 3.18)

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -415,8 +415,10 @@ void DrawAreaBase::init_font()
     // layoutにフォントをセット
     m_font = &m_defaultfont;
     m_pango_layout->set_font_description( m_font->pfd );
-#if GTKMM_CHECK_VERSION(3,0,0)
+#if GTKMM_CHECK_VERSION(3,20,0)
     m_context->set_font_description( m_font->pfd );
+#elif GTKMM_CHECK_VERSION(3,0,0)
+    override_font( m_font->pfd );
 #else
     modify_font( m_font->pfd );
 #endif
@@ -2783,8 +2785,10 @@ void DrawAreaBase::set_node_font( LAYOUT* layout )
 
         // layoutにフォントをセット
         m_pango_layout->set_font_description( m_font->pfd );
-#if GTKMM_CHECK_VERSION(3,0,0)
+#if GTKMM_CHECK_VERSION(3,20,0)
         m_context->set_font_description( m_font->pfd );
+#elif GTKMM_CHECK_VERSION(3,0,0)
+        override_font( m_font->pfd );
 #else
         modify_font( m_font->pfd );
 #endif


### PR DESCRIPTION
**このPRはアイデア検証用でありマージしません。**

GTK 3.18環境のスレビューフォントでJDim設定よりGTK設定が優先されると5chに報告がありました。
このためGTK 3.20未満の環境では[以前の実装][prev]に差し戻すパッチを公開します。
テストにご利用ください。

https://mao.5ch.net/test/read.cgi/linux/1584619744/505

[prev]: https://github.com/JDimproved/JDim/commit/ecbc982d03ba5be6d4ef735f0bd3c45dd841b71f

### 不具合の条件
`$HOME/.config/gtk-3.0/settings.ini` に `gtk-font-name = FONTNAME SIZE` のようにフォント設定がある

### 動作環境 (スレ>>505)
```
[バージョン] JDim 0.3.0-20200614(git:1eb0bac876:M)
[ディストリ ] Slackware 14.2 (x86_64)
[パッケージ] バイナリ/ソース( <配布元> )
[ DE／WM ] (unknown)
[　gtkmm 　] 3.18.1
[　glibmm 　] 2.46.4
[　TLS lib　] GnuTLS 3.6.14
[オプション ] '--with-native'
'--with-migemo'
'--with-migemodict=/usr/local/share/migemo/utf-8/migemo-dict'
[ そ の 他 ]
```

### パッチの適応方法

#### curl と patch コマンドを使う場合
**git pullなどでmasterブランチを更新してから行うことを推奨します。**

```
make clean
git chechout master
git pull
curl -L https://github.com/ma8ma/JDim/pull/41.patch | patch -p1
autoreconf -i && ./configure
make -j2

# パッチの削除
make clean
git reset --hard master
autoreconf -i && ./configure
make -j2
```

#### [hub コマンド][hub]を使う場合

```
make clean
hub checkout https://github.com/ma8ma/JDim/pull/41
autoreconf -i && ./configure
make -j2

# パッチの削除
make clean
git checkout master
git branch -D idea-fix-thread-view-font-gtk-3-18
autoreconf -i && ./configure
make -j2
```

[hub]: https://hub.github.com/

