### PR TITLE
[IDEA] Use GtkIconTheme instead of GtkWidget::render_icon_pixbuf

### DIFF
--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -134,11 +134,6 @@ namespace ARTICLE
         bool m_enable_draw;
         DRAWINFO m_drawinfo{};
 
-        // 高速スクロール描画実行
-        // DrawingAreaの領域が全て表示されているときは Gdk::Window::scroll() を使ってスクロール
-        // 一部が隠れている時はバックスクリーン内でスクロール処理してバックスクリーン全体をウィンドウにコピーする
-        bool m_scroll_window; 
-
         // キャレット情報
         CARET_POSITION m_caret_pos;           // 現在のキャレットの位置(クリックやドラッグすると移動)
         CARET_POSITION m_caret_pos_pre;       // 移動前のキャレットの位置(選択範囲の描画などで使用する)
@@ -483,7 +478,6 @@ namespace ARTICLE
         bool slot_draw( const Cairo::RefPtr< Cairo::Context >& cr );
         bool slot_scroll_event( GdkEventScroll* event );
         bool slot_leave_notify_event( GdkEventCrossing* event );
-        bool slot_visibility_notify_event( GdkEventVisibility* event );
         void slot_realize();
 
         bool slot_button_press_event( GdkEventButton* event );

--- a/src/icons/iconmanager.cpp
+++ b/src/icons/iconmanager.cpp
@@ -84,15 +84,6 @@ using namespace ICON;
 
 ICON_Manager::ICON_Manager()
 {
-    // TODO: Use Gtk::IconTheme::load_icon() instead of Gtk::Widget::render_icon_pixbuf()
-    struct Dummy : public Gtk::Image
-    {
-        Glib::RefPtr< Gdk::Pixbuf > render_icon( Gtk::BuiltinStockID stock, Gtk::BuiltinIconSize size )
-        {
-            return render_icon_pixbuf( stock, size );
-        }
-    } m_dummy;
-
     m_list_icons.resize( NUM_ICONS );
 
     m_list_icons[ ICON::JD16 ] =  Gdk::Pixbuf::create_from_inline( sizeof( icon_jd16 ), icon_jd16 );
@@ -145,18 +136,28 @@ ICON_Manager::ICON_Manager()
     //////////////////////////////
     // ツールバーのアイコン
 
+    const auto icon_theme = Gtk::IconTheme::get_default();
+    constexpr int size_menu = 16; // Gtk::ICON_SIZE_MENU
+
     // 共通
-    m_list_icons[ ICON::SEARCH_PREV ]  = m_dummy.render_icon( Gtk::Stock::GO_UP, Gtk::ICON_SIZE_MENU );
-    m_list_icons[ ICON::SEARCH_NEXT ]  = m_dummy.render_icon( Gtk::Stock::GO_DOWN, Gtk::ICON_SIZE_MENU );
-    m_list_icons[ ICON::STOPLOADING ]  = m_dummy.render_icon( Gtk::Stock::STOP, Gtk::ICON_SIZE_MENU );
+    m_list_icons[ ICON::SEARCH_PREV ] = icon_theme->load_icon( "go-up", size_menu );
+    m_list_icons[ ICON::SEARCH_NEXT ] = icon_theme->load_icon( "go-down", size_menu );
+    m_list_icons[ ICON::STOPLOADING ] = icon_theme->load_icon( "process-stop", size_menu );
     m_list_icons[ ICON::WRITE ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_write ), icon_write );
-    m_list_icons[ ICON::RELOAD ]  = m_dummy.render_icon( Gtk::Stock::REFRESH, Gtk::ICON_SIZE_MENU );
-    m_list_icons[ ICON::APPENDFAVORITE ]  = m_dummy.render_icon( Gtk::Stock::COPY, Gtk::ICON_SIZE_MENU );
-    m_list_icons[ ICON::DELETE ]  = m_dummy.render_icon( Gtk::Stock::DELETE, Gtk::ICON_SIZE_MENU );
-    m_list_icons[ ICON::QUIT ]  = m_dummy.render_icon( Gtk::Stock::CLOSE, Gtk::ICON_SIZE_MENU );
-    m_list_icons[ ICON::BACK ]  = m_dummy.render_icon( Gtk::Stock::GO_BACK, Gtk::ICON_SIZE_MENU );
-    m_list_icons[ ICON::FORWARD ]  = m_dummy.render_icon( Gtk::Stock::GO_FORWARD, Gtk::ICON_SIZE_MENU );
-    m_list_icons[ ICON::LOCK ]  = m_dummy.render_icon( Gtk::Stock::NO, Gtk::ICON_SIZE_MENU );
+    m_list_icons[ ICON::RELOAD ] = icon_theme->load_icon( "view-refresh", size_menu );
+    m_list_icons[ ICON::APPENDFAVORITE ] = icon_theme->load_icon( "edit-copy", size_menu );
+    m_list_icons[ ICON::DELETE ] = icon_theme->load_icon( "edit-delete", size_menu );
+    m_list_icons[ ICON::QUIT ] = icon_theme->load_icon( "window-close", size_menu );
+    m_list_icons[ ICON::BACK ] = icon_theme->load_icon( "go-previous", size_menu );
+    m_list_icons[ ICON::FORWARD ] = icon_theme->load_icon( "go-next", size_menu );
+    // changes-prevent is not Standard Icon Names.
+    // https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html
+    try {
+        m_list_icons[ ICON::LOCK ] = icon_theme->load_icon( "changes-prevent-symbolic", size_menu );
+    }
+    catch( Gtk::IconThemeError& ) {
+        m_list_icons[ ICON::LOCK ] = icon_theme->load_icon( "window-close", size_menu );
+    }
 
     // メイン
     m_list_icons[ ICON::BBSLISTVIEW ] = m_list_icons[ ICON::DIR ];
@@ -169,27 +170,27 @@ ICON_Manager::ICON_Manager()
     m_list_icons[ ICON::BOARDVIEW ] = m_list_icons[ ICON::BOARD ];
     m_list_icons[ ICON::ARTICLEVIEW ] = m_list_icons[ ICON::THREAD ];
     m_list_icons[ ICON::IMAGEVIEW ] = m_list_icons[ ICON::IMAGE ];
-    m_list_icons[ ICON::GO ]  = m_dummy.render_icon( Gtk::Stock::JUMP_TO, Gtk::ICON_SIZE_MENU );
-    m_list_icons[ ICON::UNDO ]  = m_dummy.render_icon( Gtk::Stock::UNDO, Gtk::ICON_SIZE_MENU );
-    m_list_icons[ ICON::REDO ]  = m_dummy.render_icon( Gtk::Stock::REDO, Gtk::ICON_SIZE_MENU );
+    m_list_icons[ ICON::GO ] = icon_theme->load_icon( "go-jump", size_menu );
+    m_list_icons[ ICON::UNDO ] = icon_theme->load_icon( "edit-undo", size_menu );
+    m_list_icons[ ICON::REDO ] = icon_theme->load_icon( "edit-redo", size_menu );
 
     // サイドバー
-    m_list_icons[ ICON::CHECK_UPDATE_ROOT ]  = m_dummy.render_icon( Gtk::Stock::REFRESH, Gtk::ICON_SIZE_MENU );
+    m_list_icons[ ICON::CHECK_UPDATE_ROOT ] = icon_theme->load_icon( "view-refresh", size_menu );
     m_list_icons[ ICON::CHECK_UPDATE_OPEN_ROOT ]  = Gdk::Pixbuf::create_from_inline( sizeof( icon_thread ), icon_thread );
 
     // スレビュー
-    m_list_icons[ ICON::SEARCH ]  = m_dummy.render_icon( Gtk::Stock::FIND, Gtk::ICON_SIZE_MENU );
-    m_list_icons[ ICON::LIVE ]  = m_dummy.render_icon( Gtk::Stock::MEDIA_PLAY, Gtk::ICON_SIZE_MENU );
+    m_list_icons[ ICON::SEARCH ] = icon_theme->load_icon( "edit-find", size_menu );
+    m_list_icons[ ICON::LIVE ] = icon_theme->load_icon( "media-playback-start", size_menu );
 
     // 検索バー
-    m_list_icons[ ICON::CLOSE_SEARCH ]  = m_dummy.render_icon( Gtk::Stock::UNDO, Gtk::ICON_SIZE_MENU );
-    m_list_icons[ ICON::CLEAR_SEARCH ]  = m_dummy.render_icon( Gtk::Stock::CLEAR, Gtk::ICON_SIZE_MENU );
-    m_list_icons[ ICON::SEARCH_AND ]  = m_dummy.render_icon( Gtk::Stock::CUT, Gtk::ICON_SIZE_MENU );
-    m_list_icons[ ICON::SEARCH_OR ]  = m_dummy.render_icon( Gtk::Stock::ADD, Gtk::ICON_SIZE_MENU );
+    m_list_icons[ ICON::CLOSE_SEARCH ] = icon_theme->load_icon( "edit-undo", size_menu );
+    m_list_icons[ ICON::CLEAR_SEARCH ] = icon_theme->load_icon( "edit-clear", size_menu );
+    m_list_icons[ ICON::SEARCH_AND ] = icon_theme->load_icon( "edit-cut", size_menu );
+    m_list_icons[ ICON::SEARCH_OR ] = icon_theme->load_icon( "list-add", size_menu );
 
     // 書き込みビュー
     m_list_icons[ ICON::PREVIEW ] = m_list_icons[ ICON::THREAD ];
-    m_list_icons[ ICON::INSERTTEXT ]  = m_dummy.render_icon( Gtk::Stock::OPEN, Gtk::ICON_SIZE_MENU );
+    m_list_icons[ ICON::INSERTTEXT ] = icon_theme->load_icon( "document-open", size_menu );
 
     load_theme();
 }

--- a/src/setupwizard.cpp
+++ b/src/setupwizard.cpp
@@ -106,11 +106,10 @@ void PageNet::slot_setup_browser()
 
 PageFont::PageFont() : Gtk::VBox(),
                        m_label( "３/５．フォントの設定をします", Gtk::ALIGN_START ),
-                       m_table( 2, 4 ),
-                       m_label_res( "スレ(_T)", Gtk::ALIGN_START, Gtk::ALIGN_START, true ),
-                       m_label_mail( "メール(_U)", Gtk::ALIGN_START, Gtk::ALIGN_START, true ),
-                       m_label_popup( "ポップアップ(_P)", Gtk::ALIGN_START, Gtk::ALIGN_START, true ),
-                       m_label_tree( "板／スレ一覧(_O)", Gtk::ALIGN_START, Gtk::ALIGN_START,  true ),
+                       m_label_res( "スレ(_T)", Gtk::ALIGN_START, Gtk::ALIGN_CENTER, true ),
+                       m_label_mail( "メール(_U)", Gtk::ALIGN_START, Gtk::ALIGN_CENTER, true ),
+                       m_label_popup( "ポップアップ(_P)", Gtk::ALIGN_START, Gtk::ALIGN_CENTER, true ),
+                       m_label_tree( "板／スレ一覧(_O)", Gtk::ALIGN_START, Gtk::ALIGN_CENTER, true ),
                        m_font_res( "スレフォント" ),
                        m_font_mail( "メール欄フォント" ),
                        m_font_popup( "ポップアップフォント" ),
@@ -136,16 +135,25 @@ PageFont::PageFont() : Gtk::VBox(),
     m_font_popup.signal_font_set().connect( sigc::mem_fun( *this, &PageFont::slot_font_popup ) );
     m_font_tree.signal_font_set().connect( sigc::mem_fun( *this, &PageFont::slot_font_tree ) );
 
-    m_table.set_spacings( 4 );
-    m_table.attach( m_label_res, 0, 1, 0, 1, Gtk::FILL, Gtk::SHRINK );
-    m_table.attach( m_label_mail, 0, 1, 1, 2, Gtk::FILL, Gtk::SHRINK );
-    m_table.attach( m_label_popup, 0, 1, 2, 3, Gtk::FILL, Gtk::SHRINK );
-    m_table.attach( m_label_tree, 0, 1, 3, 4, Gtk::FILL, Gtk::SHRINK );
+    m_font_res.set_hexpand( true );
+    m_font_mail.set_hexpand( true );
+    m_font_popup.set_hexpand( true );
+    m_font_tree.set_hexpand( true );
 
-    m_table.attach( m_font_res, 1, 2, 0, 1, Gtk::FILL | Gtk::EXPAND, Gtk::SHRINK );
-    m_table.attach( m_font_mail, 1, 2, 1, 2, Gtk::FILL | Gtk::EXPAND, Gtk::SHRINK );
-    m_table.attach( m_font_popup, 1, 2, 2, 3, Gtk::FILL | Gtk::EXPAND, Gtk::SHRINK );
-    m_table.attach( m_font_tree, 1, 2, 3, 4, Gtk::FILL | Gtk::EXPAND, Gtk::SHRINK );
+    m_table.set_row_spacing( 4 );
+    m_table.set_column_spacing( 4 );
+    m_table.set_hexpand( true );
+    constexpr int width = 1;
+    constexpr int height = 1;
+    m_table.attach( m_label_res, 0, 0, width, height );
+    m_table.attach( m_label_mail, 0, 1, width, height );
+    m_table.attach( m_label_popup, 0, 2, width, height );
+    m_table.attach( m_label_tree, 0, 3, width, height );
+
+    m_table.attach( m_font_res, 1, 0, width, height );
+    m_table.attach( m_font_mail, 1, 1, width, height );
+    m_table.attach( m_font_popup, 1, 2, width, height );
+    m_table.attach( m_font_tree, 1, 3, width, height );
 
     set_spacing( SPACING_SIZE );
     pack_start( m_hbox_label, Gtk::PACK_SHRINK );

--- a/src/setupwizard.h
+++ b/src/setupwizard.h
@@ -70,7 +70,7 @@ namespace CORE
         Gtk::Image m_icon;
         Gtk::Label m_label;
 
-        Gtk::Table m_table;
+        Gtk::Grid m_table;
 
         Gtk::Label m_label_res;
         Gtk::Label m_label_mail;


### PR DESCRIPTION
**このPRはアイデア検証用でありマージしません。**

GTK4で廃止される`Gtk::Widget::render_icon_pixbuf()`のかわりに`Gtk::IconTheme::load_icon()`を使います。

Gtk::Stockからアイコン名に変更する参考文献:
https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html
https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

<details>
<summary>コンパイラのレポート</summary>
```
../src/icons/iconmanager.cpp:90:55: error: 'Gtk::BuiltinStockID' has not been declared
   90 |         Glib::RefPtr< Gdk::Pixbuf > render_icon( Gtk::BuiltinStockID stock, Gtk::BuiltinIconSize size )
      |                                                       ^~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:92:20: error: 'render_icon_pixbuf' was not declared in this scope; did you mean 'gtk_render_icon_pixbuf'?
   92 |             return render_icon_pixbuf( stock, size );
      |                    ^~~~~~~~~~~~~~~~~~
      |                    gtk_render_icon_pixbuf
../src/icons/iconmanager.cpp:149:68: error: 'Gtk::Stock' has not been declared
  149 |     m_list_icons[ ICON::SEARCH_PREV ]  = m_dummy.render_icon( Gtk::Stock::GO_UP, Gtk::ICON_SIZE_MENU );
      |                                                                    ^~~~~
../src/icons/iconmanager.cpp:150:68: error: 'Gtk::Stock' has not been declared
  150 |     m_list_icons[ ICON::SEARCH_NEXT ]  = m_dummy.render_icon( Gtk::Stock::GO_DOWN, Gtk::ICON_SIZE_MENU );
      |                                                                    ^~~~~
../src/icons/iconmanager.cpp:151:68: error: 'Gtk::Stock' has not been declared
  151 |     m_list_icons[ ICON::STOPLOADING ]  = m_dummy.render_icon( Gtk::Stock::STOP, Gtk::ICON_SIZE_MENU );
      |                                                                    ^~~~~
../src/icons/iconmanager.cpp:153:63: error: 'Gtk::Stock' has not been declared
  153 |     m_list_icons[ ICON::RELOAD ]  = m_dummy.render_icon( Gtk::Stock::REFRESH, Gtk::ICON_SIZE_MENU );
      |                                                               ^~~~~
../src/icons/iconmanager.cpp:154:71: error: 'Gtk::Stock' has not been declared
  154 |     m_list_icons[ ICON::APPENDFAVORITE ]  = m_dummy.render_icon( Gtk::Stock::COPY, Gtk::ICON_SIZE_MENU );
      |                                                                       ^~~~~
../src/icons/iconmanager.cpp:155:63: error: 'Gtk::Stock' has not been declared
  155 |     m_list_icons[ ICON::DELETE ]  = m_dummy.render_icon( Gtk::Stock::DELETE, Gtk::ICON_SIZE_MENU );
      |                                                               ^~~~~
../src/icons/iconmanager.cpp:156:61: error: 'Gtk::Stock' has not been declared
  156 |     m_list_icons[ ICON::QUIT ]  = m_dummy.render_icon( Gtk::Stock::CLOSE, Gtk::ICON_SIZE_MENU );
      |                                                             ^~~~~
../src/icons/iconmanager.cpp:157:61: error: 'Gtk::Stock' has not been declared
  157 |     m_list_icons[ ICON::BACK ]  = m_dummy.render_icon( Gtk::Stock::GO_BACK, Gtk::ICON_SIZE_MENU );
      |                                                             ^~~~~
../src/icons/iconmanager.cpp:158:64: error: 'Gtk::Stock' has not been declared
  158 |     m_list_icons[ ICON::FORWARD ]  = m_dummy.render_icon( Gtk::Stock::GO_FORWARD, Gtk::ICON_SIZE_MENU );
      |                                                                ^~~~~
../src/icons/iconmanager.cpp:159:61: error: 'Gtk::Stock' has not been declared
  159 |     m_list_icons[ ICON::LOCK ]  = m_dummy.render_icon( Gtk::Stock::NO, Gtk::ICON_SIZE_MENU );
      |                                                             ^~~~~
../src/icons/iconmanager.cpp:172:59: error: 'Gtk::Stock' has not been declared
  172 |     m_list_icons[ ICON::GO ]  = m_dummy.render_icon( Gtk::Stock::JUMP_TO, Gtk::ICON_SIZE_MENU );
      |                                                           ^~~~~
../src/icons/iconmanager.cpp:173:61: error: 'Gtk::Stock' has not been declared
  173 |     m_list_icons[ ICON::UNDO ]  = m_dummy.render_icon( Gtk::Stock::UNDO, Gtk::ICON_SIZE_MENU );
      |                                                             ^~~~~
../src/icons/iconmanager.cpp:174:61: error: 'Gtk::Stock' has not been declared
  174 |     m_list_icons[ ICON::REDO ]  = m_dummy.render_icon( Gtk::Stock::REDO, Gtk::ICON_SIZE_MENU );
      |                                                             ^~~~~
../src/icons/iconmanager.cpp:177:74: error: 'Gtk::Stock' has not been declared
  177 |     m_list_icons[ ICON::CHECK_UPDATE_ROOT ]  = m_dummy.render_icon( Gtk::Stock::REFRESH, Gtk::ICON_SIZE_MENU );
      |                                                                          ^~~~~
../src/icons/iconmanager.cpp:181:63: error: 'Gtk::Stock' has not been declared
  181 |     m_list_icons[ ICON::SEARCH ]  = m_dummy.render_icon( Gtk::Stock::FIND, Gtk::ICON_SIZE_MENU );
      |                                                               ^~~~~
../src/icons/iconmanager.cpp:182:61: error: 'Gtk::Stock' has not been declared
  182 |     m_list_icons[ ICON::LIVE ]  = m_dummy.render_icon( Gtk::Stock::MEDIA_PLAY, Gtk::ICON_SIZE_MENU );
      |                                                             ^~~~~
../src/icons/iconmanager.cpp:185:69: error: 'Gtk::Stock' has not been declared
  185 |     m_list_icons[ ICON::CLOSE_SEARCH ]  = m_dummy.render_icon( Gtk::Stock::UNDO, Gtk::ICON_SIZE_MENU );
      |                                                                     ^~~~~
../src/icons/iconmanager.cpp:186:69: error: 'Gtk::Stock' has not been declared
  186 |     m_list_icons[ ICON::CLEAR_SEARCH ]  = m_dummy.render_icon( Gtk::Stock::CLEAR, Gtk::ICON_SIZE_MENU );
      |                                                                     ^~~~~
../src/icons/iconmanager.cpp:187:67: error: 'Gtk::Stock' has not been declared
  187 |     m_list_icons[ ICON::SEARCH_AND ]  = m_dummy.render_icon( Gtk::Stock::CUT, Gtk::ICON_SIZE_MENU );
      |                                                                   ^~~~~
../src/icons/iconmanager.cpp:188:66: error: 'Gtk::Stock' has not been declared
  188 |     m_list_icons[ ICON::SEARCH_OR ]  = m_dummy.render_icon( Gtk::Stock::ADD, Gtk::ICON_SIZE_MENU );
      |                                                                  ^~~~~
../src/icons/iconmanager.cpp:192:67: error: 'Gtk::Stock' has not been declared
  192 |     m_list_icons[ ICON::INSERTTEXT ]  = m_dummy.render_icon( Gtk::Stock::OPEN, Gtk::ICON_SIZE_MENU );
      |                                                                   ^~~~~
```
</details>

---
### パッチの適応方法

#### git clone コマンドを使う方法 (一時的なcloneで使い捨てる)

```
git clone -b idea-use-gtkicontheme-instead-of-gtkwidget-render_icon_pixbuf --depth 1 https://github.com/ma8ma/JDim.git temp-pr
cd temp-pr

meson debugdir
meson compile -C debugdir

# 実行
./debugdir/src/jdim

# パッチの削除
cd ../
rm -rf temp-pr
```

#### curl と patch コマンドを使う場合
※ git pullなどでmasterブランチを更新してから行うことを推奨します。

```
git chechout master
git pull
curl -L https://github.com/ma8ma/JDim/pull/47.patch | patch -p1
meson debugdir
meson compile -C debugdir

# 実行
./debugdir/src/jdim

# パッチの削除
rm -rf debugdir
git reset --hard master
```

#### [hub コマンド][hub]を使う場合

```
hub checkout https://github.com/ma8ma/JDim/pull/47
meson debugdir
meson compile -C debugdir

# 実行
./debugdir/src/jdim

# パッチの削除
rm -rf debugdir
git checkout master
git branch -D idea-use-gtkicontheme-instead-of-gtkwidget-render_icon_pixbuf
```

[hub]: https://hub.github.com/
