### PR TITLE
[IDEA] Use glib-compile-resources instead of gdk-pixbuf-csource

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         sets:
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             cc: gcc-5
             cxx: g++-5
             package: g++-5
@@ -41,7 +41,7 @@ jobs:
             package: g++-8
             debug: -Og -D_DEBUG
 
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             cc: clang-4.0
             cxx: clang++-4.0
             package: clang-4.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 buildinfo.h
 src/jdim
 src/**/*.a
+src/icons.gresource.cpp
 src/icons/*.h
 !src/icons/iconmanager.h
 !src/icons/iconid.h

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: cpp
 
 branches:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,8 +1,21 @@
 SUBDIRS = dbtree dbimg bbslist board article image message jdlib skeleton history config icons sound xml control
 
+
+DISTCLEANFILES = icons.gresource.cpp
+
+icons.gresource.cpp: icons/icons.gresource.xml
+	glib-compile-resources $^ --sourcedir icons --internal --generate --target $@ --dependency-file .deps/$@.Po
+
+# 静的ライブラリに GResource オブジェクトを含めると __attribute__((constructor)) gcc拡張が機能しない
+# そのためオブジェクトファイルを実行ファイルのターゲットに入れる
+icons.gresource.o: icons.gresource.cpp
+	$(CXX) $(AM_CPPFLAGS) $(AM_CXXFLAGS) -o $@ -c $<
+
+
 bin_PROGRAMS = jdim
 
 jdim_LDADD = \
+	./icons.gresource.o \
 	./dbimg/libdbimg.a \
 	./bbslist/libbbslist.a \
 	./board/libboard.a \

--- a/src/icons/Makefile.am
+++ b/src/icons/Makefile.am
@@ -3,26 +3,8 @@ noinst_LIBRARIES = libicon.a
 libicon_a_SOURCES = \
 	iconmanager.cpp
 
-icon_headers = jd16.h jd32.h jd48.h jd96.h \
-	dir.h board.h board_update.h board_updated.h thread.h thread_update.h thread_updated.h thread_old.h \
-	image.h link.h loading.h loading_stop.h check.h down.h \
-	update.h newthread.h newthread_hour.h broken_subject.h bkmark.h bkmark_broken_subject.h bkmark_update.h bkmark_thread.h favorite.h write.h post.h post_refer.h \
-	hist.h hist_board.h hist_close.h hist_closeboard.h hist_closeimg.h info.h
-
 noinst_HEADERS = \
-	iconmanager.h iconid.h iconfiles.h $(icon_headers)
+	iconmanager.h iconid.h iconfiles.h
 
 AM_CXXFLAGS = @GTKMM_CFLAGS@
 AM_CPPFLAGS = -I$(top_srcdir)/src
-
-DISTCLEANFILES = $(icon_headers)
-
-clean_icons :
-	rm -rf $(icon_headers)
-
-iconmanager.cpp : $(icon_headers)
-
-SUFFIXES = .png .h
-
-.png.h:
-	gdk-pixbuf-csource --raw --name=icon_$* $< > $@

--- a/src/icons/iconmanager.cpp
+++ b/src/icons/iconmanager.cpp
@@ -9,47 +9,6 @@
 
 #include "cache.h"
 
-#include "jd16.h"
-#include "jd32.h"
-#include "jd48.h"
-#include "jd96.h"
-
-#include "bkmark_update.h"
-#include "bkmark.h"
-#include "bkmark_broken_subject.h"
-#include "bkmark_thread.h"
-
-#include "update.h"
-#include "newthread.h"
-#include "newthread_hour.h"
-#include "broken_subject.h"
-#include "check.h"
-#include "down.h"
-#include "write.h"
-#include "post.h"
-#include "post_refer.h"
-#include "loading.h"
-#include "loading_stop.h"
-
-#include "dir.h"
-#include "favorite.h"
-#include "hist.h"
-#include "hist_board.h"
-#include "hist_close.h"
-#include "hist_closeboard.h"
-#include "hist_closeimg.h"
-
-#include "board.h"
-#include "board_update.h"
-#include "board_updated.h"
-#include "thread.h"
-#include "thread_update.h"
-#include "thread_updated.h"
-#include "thread_old.h"
-#include "image.h"
-#include "link.h"
-#include "info.h"
-
 #include <cstring>
 
 ICON::ICON_Manager* instance_icon_manager = nullptr;
@@ -86,45 +45,45 @@ ICON_Manager::ICON_Manager()
 {
     m_list_icons.resize( NUM_ICONS );
 
-    m_list_icons[ ICON::JD16 ] =  Gdk::Pixbuf::create_from_inline( sizeof( icon_jd16 ), icon_jd16 );
-    m_list_icons[ ICON::JD32 ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_jd32 ), icon_jd32 );
-    m_list_icons[ ICON::JD48 ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_jd48 ), icon_jd48 );
-    m_list_icons[ ICON::JD96 ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_jd96 ), icon_jd96 );
+    m_list_icons[ ICON::JD16 ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/jd16.png" );
+    m_list_icons[ ICON::JD32 ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/jd32.png" );
+    m_list_icons[ ICON::JD48 ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/jd48.png" );
+    m_list_icons[ ICON::JD96 ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/jd96.png" );
 
     // サイドバーで使用するアイコン
-    m_list_icons[ ICON::DIR ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_dir ), icon_dir );
-    m_list_icons[ ICON::IMAGE ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_image ), icon_image );
-    m_list_icons[ ICON::LINK ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_link ), icon_link );
+    m_list_icons[ ICON::DIR ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/dir.png" );
+    m_list_icons[ ICON::IMAGE ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/image.png" );
+    m_list_icons[ ICON::LINK ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/link.png" );
 
     // サイドバーやタブで使用するアイコン
-    m_list_icons[ ICON::BOARD ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_board ), icon_board );
-    m_list_icons[ ICON::BOARD_UPDATE ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_board_update ), icon_board_update );
-    m_list_icons[ ICON::THREAD ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_thread ), icon_thread );
-    m_list_icons[ ICON::THREAD_UPDATE ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_thread_update ), icon_thread_update );
-    m_list_icons[ ICON::THREAD_OLD ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_thread_old ), icon_thread_old );
+    m_list_icons[ ICON::BOARD ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/board.png" );
+    m_list_icons[ ICON::BOARD_UPDATE ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/board_update.png" );
+    m_list_icons[ ICON::THREAD ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/thread.png" );
+    m_list_icons[ ICON::THREAD_UPDATE ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/thread_update.png" );
+    m_list_icons[ ICON::THREAD_OLD ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/thread_old.png" );
 
     // タブで使用するアイコン
-    m_list_icons[ ICON::BOARD_UPDATED ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_board_updated ), icon_board_updated );
-    m_list_icons[ ICON::THREAD_UPDATED ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_thread_updated ), icon_thread_updated );
-    m_list_icons[ ICON::LOADING ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_loading ), icon_loading );
-    m_list_icons[ ICON::LOADING_STOP ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_loading_stop ), icon_loading_stop );
+    m_list_icons[ ICON::BOARD_UPDATED ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/board_updated.png" );
+    m_list_icons[ ICON::THREAD_UPDATED ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/thread_updated.png" );
+    m_list_icons[ ICON::LOADING ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/loading.png" );
+    m_list_icons[ ICON::LOADING_STOP ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/loading_stop.png" );
 
     // スレ一覧で使用するアイコン
-    m_list_icons[ ICON::BKMARK_UPDATE ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_bkmark_update ), icon_bkmark_update );
-    m_list_icons[ ICON::BKMARK_BROKEN_SUBJECT ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_bkmark_broken_subject ), icon_bkmark_broken_subject );
-    m_list_icons[ ICON::BKMARK ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_bkmark ), icon_bkmark );
-    m_list_icons[ ICON::UPDATE ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_update ), icon_update );
-    m_list_icons[ ICON::NEWTHREAD ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_newthread ), icon_newthread );
-    m_list_icons[ ICON::NEWTHREAD_HOUR ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_newthread_hour ), icon_newthread_hour );
-    m_list_icons[ ICON::BROKEN_SUBJECT ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_broken_subject ), icon_broken_subject );
-    m_list_icons[ ICON::CHECK ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_check ), icon_check );
-    m_list_icons[ ICON::OLD ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_down ), icon_down );
-    m_list_icons[ ICON::INFO ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_info ), icon_info );
+    m_list_icons[ ICON::BKMARK_UPDATE ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/bkmark_update.png" );
+    m_list_icons[ ICON::BKMARK_BROKEN_SUBJECT ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/bkmark_broken_subject.png" );
+    m_list_icons[ ICON::BKMARK ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/bkmark.png" );
+    m_list_icons[ ICON::UPDATE ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/update.png" );
+    m_list_icons[ ICON::NEWTHREAD ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/newthread.png" );
+    m_list_icons[ ICON::NEWTHREAD_HOUR ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/newthread_hour.png" );
+    m_list_icons[ ICON::BROKEN_SUBJECT ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/broken_subject.png" );
+    m_list_icons[ ICON::CHECK ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/check.png" );
+    m_list_icons[ ICON::OLD ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/down.png" );
+    m_list_icons[ ICON::INFO ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/info.png" );
 
     // スレビューで使用するアイコン
-    m_list_icons[ ICON::BKMARK_THREAD ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_bkmark_thread ), icon_bkmark_thread );
-    m_list_icons[ ICON::POST ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_post ), icon_post );
-    m_list_icons[ ICON::POST_REFER ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_post_refer ), icon_post_refer );
+    m_list_icons[ ICON::BKMARK_THREAD ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/bkmark_thread.png" );
+    m_list_icons[ ICON::POST ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/post.png" );
+    m_list_icons[ ICON::POST_REFER ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/post_refer.png" );
 
     // その他
     m_list_icons[ ICON::DOWN ] = m_list_icons[ ICON::OLD ];
@@ -147,7 +106,7 @@ ICON_Manager::ICON_Manager()
     m_list_icons[ ICON::SEARCH_PREV ] = icon_theme->load_icon( "go-up", size_menu );
     m_list_icons[ ICON::SEARCH_NEXT ] = icon_theme->load_icon( "go-down", size_menu );
     m_list_icons[ ICON::STOPLOADING ] = icon_theme->load_icon( "process-stop", size_menu );
-    m_list_icons[ ICON::WRITE ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_write ), icon_write );
+    m_list_icons[ ICON::WRITE ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/write.png" );
     m_list_icons[ ICON::RELOAD ] = icon_theme->load_icon( "view-refresh", size_menu );
     m_list_icons[ ICON::APPENDFAVORITE ] = icon_theme->load_icon( "edit-copy", size_menu );
     m_list_icons[ ICON::DELETE ] = icon_theme->load_icon( "edit-delete", size_menu );
@@ -164,12 +123,12 @@ ICON_Manager::ICON_Manager()
 
     // メイン
     m_list_icons[ ICON::BBSLISTVIEW ] = m_list_icons[ ICON::DIR ];
-    m_list_icons[ ICON::FAVORITEVIEW ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_favorite ), icon_favorite );
-    m_list_icons[ ICON::HISTVIEW ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_hist ), icon_hist );
-    m_list_icons[ ICON::HIST_BOARDVIEW ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_hist_board ), icon_hist_board );
-    m_list_icons[ ICON::HIST_CLOSEVIEW ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_hist_close ), icon_hist_close );
-    m_list_icons[ ICON::HIST_CLOSEBOARDVIEW ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_hist_closeboard ), icon_hist_closeboard );
-    m_list_icons[ ICON::HIST_CLOSEIMGVIEW ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_hist_closeimg ), icon_hist_closeimg );
+    m_list_icons[ ICON::FAVORITEVIEW ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/favorite.png" );
+    m_list_icons[ ICON::HISTVIEW ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/hist.png" );
+    m_list_icons[ ICON::HIST_BOARDVIEW ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/hist_board.png" );
+    m_list_icons[ ICON::HIST_CLOSEVIEW ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/hist_close.png" );
+    m_list_icons[ ICON::HIST_CLOSEBOARDVIEW ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/hist_closeboard.png" );
+    m_list_icons[ ICON::HIST_CLOSEIMGVIEW ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/hist_closeimg.png" );
     m_list_icons[ ICON::BOARDVIEW ] = m_list_icons[ ICON::BOARD ];
     m_list_icons[ ICON::ARTICLEVIEW ] = m_list_icons[ ICON::THREAD ];
     m_list_icons[ ICON::IMAGEVIEW ] = m_list_icons[ ICON::IMAGE ];
@@ -179,7 +138,7 @@ ICON_Manager::ICON_Manager()
 
     // サイドバー
     m_list_icons[ ICON::CHECK_UPDATE_ROOT ] = icon_theme->load_icon( "view-refresh", size_menu );
-    m_list_icons[ ICON::CHECK_UPDATE_OPEN_ROOT ]  = Gdk::Pixbuf::create_from_inline( sizeof( icon_thread ), icon_thread );
+    m_list_icons[ ICON::CHECK_UPDATE_OPEN_ROOT ] = Gdk::Pixbuf::create_from_resource( "/com/github/jdimproved/JDim/thread.png" );
 
     // スレビュー
     m_list_icons[ ICON::SEARCH ] = icon_theme->load_icon( "edit-find", size_menu );

--- a/src/icons/icons.gresource.xml
+++ b/src/icons/icons.gresource.xml
@@ -1,0 +1,41 @@
+<?xml versoin="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/com/github/jdimproved/JDim">
+    <file preprocess="to-pixdata">bkmark.png</file>
+    <file preprocess="to-pixdata">bkmark_broken_subject.png</file>
+    <file preprocess="to-pixdata">bkmark_thread.png</file>
+    <file preprocess="to-pixdata">bkmark_update.png</file>
+    <file preprocess="to-pixdata">board.png</file>
+    <file preprocess="to-pixdata">board_update.png</file>
+    <file preprocess="to-pixdata">board_updated.png</file>
+    <file preprocess="to-pixdata">broken_subject.png</file>
+    <file preprocess="to-pixdata">check.png</file>
+    <file preprocess="to-pixdata">dir.png</file>
+    <file preprocess="to-pixdata">down.png</file>
+    <file preprocess="to-pixdata">favorite.png</file>
+    <file preprocess="to-pixdata">hist.png</file>
+    <file preprocess="to-pixdata">hist_board.png</file>
+    <file preprocess="to-pixdata">hist_close.png</file>
+    <file preprocess="to-pixdata">hist_closeboard.png</file>
+    <file preprocess="to-pixdata">hist_closeimg.png</file>
+    <file preprocess="to-pixdata">image.png</file>
+    <file preprocess="to-pixdata">info.png</file>
+    <file preprocess="to-pixdata">jd16.png</file>
+    <file preprocess="to-pixdata">jd32.png</file>
+    <file preprocess="to-pixdata">jd48.png</file>
+    <file preprocess="to-pixdata">jd96.png</file>
+    <file preprocess="to-pixdata">link.png</file>
+    <file preprocess="to-pixdata">loading.png</file>
+    <file preprocess="to-pixdata">loading_stop.png</file>
+    <file preprocess="to-pixdata">newthread.png</file>
+    <file preprocess="to-pixdata">newthread_hour.png</file>
+    <file preprocess="to-pixdata">post.png</file>
+    <file preprocess="to-pixdata">post_refer.png</file>
+    <file preprocess="to-pixdata">thread.png</file>
+    <file preprocess="to-pixdata">thread_old.png</file>
+    <file preprocess="to-pixdata">thread_update.png</file>
+    <file preprocess="to-pixdata">thread_updated.png</file>
+    <file preprocess="to-pixdata">update.png</file>
+    <file preprocess="to-pixdata">write.png</file>
+  </gresource>
+</gresources>

--- a/src/icons/meson.build
+++ b/src/icons/meson.build
@@ -1,52 +1,20 @@
-gdk_pixbuf_csource = find_program('gdk-pixbuf-csource')
-gen = generator(gdk_pixbuf_csource,
-                output : '@BASENAME@.h',
-                capture : true,
-                arguments : ['--raw', '--build-list', 'icon_@BASENAME@', '@INPUT@'])
+# meson 組み込みの [gnome] モジュールを使うと .c ファイルが出力されるため
+# コマンドを明示的に指定して .cpp ファイルを生成し C++ コンパイラで処理する
+#
+# 静的ライブラリに GResource オブジェクトを含めると __attribute__((constructor)) gcc拡張が機能しない
+# そのため実行ファイルのターゲット jdim_exe のソースに入れる
+#
+# [gnome]: https://mesonbuild.com/Gnome-module.html
 
-icon_files = [
-  'bkmark.png',
-  'bkmark_broken_subject.png',
-  'bkmark_thread.png',
-  'bkmark_update.png',
-  'board.png',
-  'board_update.png',
-  'board_updated.png',
-  'broken_subject.png',
-  'check.png',
-  'dir.png',
-  'down.png',
-  'favorite.png',
-  'hist.png',
-  'hist_board.png',
-  'hist_close.png',
-  'hist_closeboard.png',
-  'hist_closeimg.png',
-  'image.png',
-  'info.png',
-  'jd16.png',
-  'jd32.png',
-  'jd48.png',
-  'jd96.png',
-  'link.png',
-  'loading.png',
-  'loading_stop.png',
-  'newthread.png',
-  'newthread_hour.png',
-  'post.png',
-  'post_refer.png',
-  'thread.png',
-  'thread_old.png',
-  'thread_update.png',
-  'thread_updated.png',
-  'update.png',
-  'write.png',
-]
+glib_compile_resources = find_program('glib-compile-resources')
+icons_gresource_gen = generator(glib_compile_resources,
+                                output : '@BASENAME@.cpp',
+                                depfile : '@BASENAME@.cpp.d',
+                                arguments : ['@INPUT@', '--sourcedir', '@CURRENT_SOURCE_DIR@',
+                                             '--internal', '--generate', '--target', '@OUTPUT@',
+                                             '--dependency-file', '@DEPFILE@'])
+icons_gresource_cpp = icons_gresource_gen.process('icons.gresource.xml')
 
-generated_headers = []
-foreach f : icon_files
-  generated_headers += gen.process(f)
-endforeach
 
 sources = [
   'iconmanager.cpp',
@@ -54,7 +22,7 @@ sources = [
 
 
 icon_lib = static_library(
-  'icon', [sources, generated_headers],
+  'icon', [sources],
   dependencies : gtkmm_dep,
   include_directories : include_directories('..'),
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -112,7 +112,7 @@ jdim_libs = [
 
 
 jdim_exe = executable(
-  'jdim', [core_sources, sources, buildinfo_h, config_h],
+  'jdim', [core_sources, sources, buildinfo_h, config_h, icons_gresource_cpp],
   dependencies : jdim_deps,
   include_directories : jdim_incs,
   link_with : jdim_libs,


### PR DESCRIPTION
**このPRはアイデア検証用でありマージしません。**

GTK4で廃止される`Gdk::Pixbuf::create_from_lnline()`を`Gdk::Pixbuf::create_from_resource()`で置き換えます。

#### GResource の参考文献
- https://developer.gnome.org/gio/stable/GResource.html
- https://developer.gnome.org/gio/stable/glib-compile-resources.html
- https://mesonbuild.com/Gnome-module.html
- https://stackoverflow.com/questions/1202494/why-doesnt-attribute-constructor-work-in-a-static-library

非推奨のシンボルを無効化するマクロ
```
GDK_DISABLE_DEPRECATED
GTK_DISABLE_DEPRECATED
GDKMM_DISABLE_DEPRECATED
GTKMM_DISABLE_DEPRECATED
GIOMM_DISABLE_DEPRECATED
GLIBMM_DISABLE_DEPRECATED
```

<details>
<summary>コンパイラのレポート</summary>

```
../src/icons/iconmanager.cpp:98:48: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
   98 |     m_list_icons[ ICON::JD16 ] =  Gdk::Pixbuf::create_from_inline( sizeof( icon_jd16 ), icon_jd16 );
      |                                                ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:99:47: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
   99 |     m_list_icons[ ICON::JD32 ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_jd32 ), icon_jd32 );
      |                                               ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:100:47: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  100 |     m_list_icons[ ICON::JD48 ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_jd48 ), icon_jd48 );
      |                                               ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:101:47: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  101 |     m_list_icons[ ICON::JD96 ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_jd96 ), icon_jd96 );
      |                                               ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:104:46: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  104 |     m_list_icons[ ICON::DIR ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_dir ), icon_dir );
      |                                              ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:105:48: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  105 |     m_list_icons[ ICON::IMAGE ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_image ), icon_image );
      |                                                ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:106:47: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  106 |     m_list_icons[ ICON::LINK ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_link ), icon_link );
      |                                               ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:109:48: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  109 |     m_list_icons[ ICON::BOARD ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_board ), icon_board );
      |                                                ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:110:55: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  110 |     m_list_icons[ ICON::BOARD_UPDATE ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_board_update ), icon_board_update );
      |                                                       ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:111:49: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  111 |     m_list_icons[ ICON::THREAD ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_thread ), icon_thread );
      |                                                 ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:112:56: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  112 |     m_list_icons[ ICON::THREAD_UPDATE ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_thread_update ), icon_thread_update );
      |                                                        ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:113:53: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  113 |     m_list_icons[ ICON::THREAD_OLD ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_thread_old ), icon_thread_old );
      |                                                     ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:116:56: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  116 |     m_list_icons[ ICON::BOARD_UPDATED ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_board_updated ), icon_board_updated );
      |                                                        ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:117:57: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  117 |     m_list_icons[ ICON::THREAD_UPDATED ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_thread_updated ), icon_thread_updated );
      |                                                         ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:118:50: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  118 |     m_list_icons[ ICON::LOADING ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_loading ), icon_loading );
      |                                                  ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:119:55: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  119 |     m_list_icons[ ICON::LOADING_STOP ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_loading_stop ), icon_loading_stop );
      |                                                       ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:122:56: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  122 |     m_list_icons[ ICON::BKMARK_UPDATE ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_bkmark_update ), icon_bkmark_update );
      |                                                        ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:123:64: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  123 |     m_list_icons[ ICON::BKMARK_BROKEN_SUBJECT ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_bkmark_broken_subject ), icon_bkmark_broken_subject );
      |                                                                ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:124:49: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  124 |     m_list_icons[ ICON::BKMARK ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_bkmark ), icon_bkmark );
      |                                                 ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:125:49: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  125 |     m_list_icons[ ICON::UPDATE ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_update ), icon_update );
      |                                                 ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:126:52: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  126 |     m_list_icons[ ICON::NEWTHREAD ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_newthread ), icon_newthread );
      |                                                    ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:127:57: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  127 |     m_list_icons[ ICON::NEWTHREAD_HOUR ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_newthread_hour ), icon_newthread_hour );
      |                                                         ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:128:57: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  128 |     m_list_icons[ ICON::BROKEN_SUBJECT ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_broken_subject ), icon_broken_subject );
      |                                                         ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:129:48: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  129 |     m_list_icons[ ICON::CHECK ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_check ), icon_check );
      |                                                ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:130:46: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  130 |     m_list_icons[ ICON::OLD ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_down ), icon_down );
      |                                              ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:131:47: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  131 |     m_list_icons[ ICON::INFO ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_info ), icon_info );
      |                                               ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:134:56: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  134 |     m_list_icons[ ICON::BKMARK_THREAD ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_bkmark_thread ), icon_bkmark_thread );
      |                                                        ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:135:47: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  135 |     m_list_icons[ ICON::POST ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_post ), icon_post );
      |                                               ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:136:53: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  136 |     m_list_icons[ ICON::POST_REFER ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_post_refer ), icon_post_refer );
      |                                                     ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:152:48: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  152 |     m_list_icons[ ICON::WRITE ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_write ), icon_write );
      |                                                ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:163:55: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  163 |     m_list_icons[ ICON::FAVORITEVIEW ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_favorite ), icon_favorite );
      |                                                       ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:164:51: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  164 |     m_list_icons[ ICON::HISTVIEW ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_hist ), icon_hist );
      |                                                   ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:165:57: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  165 |     m_list_icons[ ICON::HIST_BOARDVIEW ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_hist_board ), icon_hist_board );
      |                                                         ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:166:57: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  166 |     m_list_icons[ ICON::HIST_CLOSEVIEW ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_hist_close ), icon_hist_close );
      |                                                         ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:167:62: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  167 |     m_list_icons[ ICON::HIST_CLOSEBOARDVIEW ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_hist_closeboard ), icon_hist_closeboard );
      |                                                              ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:168:60: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  168 |     m_list_icons[ ICON::HIST_CLOSEIMGVIEW ] = Gdk::Pixbuf::create_from_inline( sizeof( icon_hist_closeimg ), icon_hist_closeimg );
      |                                                            ^~~~~~~~~~~~~~~~~~
../src/icons/iconmanager.cpp:178:66: error: 'create_from_inline' is not a member of 'Gdk::Pixbuf'
  178 |     m_list_icons[ ICON::CHECK_UPDATE_OPEN_ROOT ]  = Gdk::Pixbuf::create_from_inline( sizeof( icon_thread ), icon_thread );
      |                                                                  ^~~~~~~~~~~~~~~~~~
```

</details>

---
### パッチの適応方法

#### git clone コマンドを使う方法 (一時的なcloneで使い捨てる)

```
git clone -b idea-use-glib-compile-resources --depth 1 https://github.com/ma8ma/JDim.git temp
cd temp

meson debugdir
meson compile -C debugdir

# 実行
./debugdir/src/jdim

# パッチの削除
cd ../
rm -rf temp
```

#### curl と patch コマンドを使う場合
※ git pullなどでmasterブランチを更新してから行うことを推奨します。

```
git chechout master
git pull
curl -L https://github.com/ma8ma/JDim/pull/51.patch | patch -p1
meson debugdir
meson compile -C debugdir

# 実行
./debugdir/src/jdim

# パッチの削除
rm -rf debugdir
git reset --hard master
```

#### [hub コマンド][hub]を使う場合

```
hub checkout https://github.com/ma8ma/JDim/pull/51
meson debugdir
meson compile -C debugdir

# 実行
./debugdir/src/jdim

# パッチの削除
rm -rf debugdir
git checkout master
git branch -D idea-use-glib-compile-resources
```

[hub]: https://hub.github.com/
