### PR TITLE
[IDEA] Improve JDLIB::Regex class

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -3565,7 +3565,7 @@ int DrawAreaBase::search( const std::list< std::string >& list_query, const bool
 
                             if( min_offset == -1 || regex.pos( 0 ) <= min_offset ){
                                 min_offset = regex.pos( 0 );
-                                lng = regex.str( 0 ).length();
+                                lng = regex.length( 0 );
                             }
                         }
                     }

--- a/src/bbslist/bbslistviewbase.cpp
+++ b/src/bbslist/bbslistviewbase.cpp
@@ -2673,9 +2673,6 @@ void BBSListViewBase::replace_thread( const std::string& url, const std::string&
 //
 void BBSListViewBase::exec_search()
 {
-    JDLIB::Regex regex_name;
-    JDLIB::Regex regex_url;
-
     CORE::core_set_command( "set_info", "", "" );
 
     std::string query = get_search_query();
@@ -2704,17 +2701,19 @@ void BBSListViewBase::exec_search()
     std::cout << "BBSListViewBase::exec_search() path = " << path.to_string() << " query = " << query << std::endl;
 #endif
 
-    const bool icase_name = true; // 大文字小文字区別しない
-    const bool newline_name = true; // . に改行をマッチさせない
-    const bool usemigemo_name = true; // migemo使用
-    const bool wchar_name = true;  // 全角半角の区別をしない
-    regex_name.compile( query, icase_name, newline_name, usemigemo_name, wchar_name );
+    constexpr bool icase_name = true; // 大文字小文字区別しない
+    constexpr bool newline_name = true; // . に改行をマッチさせない
+    constexpr bool usemigemo_name = true; // migemo使用
+    constexpr bool wchar_name = true;  // 全角半角の区別をしない
+    const JDLIB::RegexPattern regex_name( query, icase_name, newline_name, usemigemo_name, wchar_name );
 
-    const bool icase_url = true; // 大文字小文字区別しない
-    const bool newline_url = true;
-    const bool usemigemo_url = false;
-    const bool wchar_url = false;
-    regex_url.compile( query, icase_url, newline_url, usemigemo_url, wchar_url );
+    constexpr bool icase_url = true; // 大文字小文字区別しない
+    constexpr bool newline_url = true;
+    constexpr bool usemigemo_url = false;
+    constexpr bool wchar_url = false;
+    const JDLIB::RegexPattern regex_url( query, icase_url, newline_url, usemigemo_url, wchar_url );
+
+    JDLIB::Regex regex;
 
     bool hit = false;
     for(;;){
@@ -2749,7 +2748,7 @@ void BBSListViewBase::exec_search()
         const std::string url = path2url( path );
 
         const size_t offset = 0;
-        if( regex_name.exec( name, offset ) || regex_url.exec( url, offset ) ) hit = true;
+        if( regex.match( regex_name, name, offset ) || regex.match( regex_url, url, offset ) ) hit = true;
 
         // 一周したら終わり
         if( path == path_start ) break;

--- a/src/board/boardviewbase.cpp
+++ b/src/board/boardviewbase.cpp
@@ -2576,15 +2576,16 @@ bool BoardViewBase::drawout( const bool force_reset )
     unsorted_column();
 
     JDLIB::Regex regex;
-    const bool icase = true; // 大文字小文字区別しない
-    const bool newline = true; // . に改行をマッチさせない
-    const bool usemigemo = true; // migemo使用
-    const bool wchar = true;  // 全角半角の区別をしない
+    JDLIB::RegexPattern regexptn;
+    constexpr bool icase = true; // 大文字小文字区別しない
+    constexpr bool newline = true; // . に改行をマッチさせない
+    constexpr bool usemigemo = true; // migemo使用
+    constexpr bool wchar = true;  // 全角半角の区別をしない
 
     Gtk::TreeModel::Children child = m_liststore->children();
     Gtk::TreeModel::Children::iterator it = child.begin();
 
-    if ( ! reset ) regex.compile( query, icase, newline, usemigemo, wchar );
+    if ( ! reset ) regexptn.set( query, icase, newline, usemigemo, wchar );
 
     for( ; it != child.end() ; ++it ){
 
@@ -2592,7 +2593,7 @@ bool BoardViewBase::drawout( const bool force_reset )
         const Glib::ustring subject = row[ m_columns.m_col_subject ];
 
         if( reset ) row[ m_columns.m_col_drawbg ] = false;
-        else if( regex.exec( subject, 0 ) ){
+        else if( regex.match( regexptn, subject, 0 ) ){
             row[ m_columns.m_col_drawbg ] = true;
             ++hit;
 
@@ -2660,11 +2661,11 @@ void BoardViewBase::exec_search()
 
     Gtk::TreePath path_start = path;
     JDLIB::Regex regex;
-    const size_t offset = 0;
-    const bool icase = true; // 大文字小文字区別しない
-    const bool newline = true; // . に改行をマッチさせない
-    const bool usemigemo = true; // migemo使用
-    const bool wchar = true;  // 全角半角の区別をしない
+    constexpr size_t offset = 0;
+    constexpr bool icase = true; // 大文字小文字区別しない
+    constexpr bool newline = true; // . に改行をマッチさせない
+    constexpr bool usemigemo = true; // migemo使用
+    constexpr bool wchar = true;  // 全角半角の区別をしない
 
 #ifdef _DEBUG
     std::cout << "BoardViewBase::search start = " << path_start.to_string() << " query = " <<  query << std::endl;

--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -1120,7 +1120,7 @@ void ConfigItems::set_proxy_for2ch( const std::string& proxy )
 
     if( regex.exec( "([^/]+:[^/]+@)(.+)$" , proxy, offset, icase, newline, usemigemo, wchar ) )
     {
-        proxy_basicauth_for2ch = regex.str( 1 ).substr( 0, regex.str( 1 ).length() - 1 );
+        proxy_basicauth_for2ch = regex.str( 1 ).substr( 0, regex.length( 1 ) - 1 );
         proxy_for2ch = regex.str( 2 );
     }
 }
@@ -1141,7 +1141,7 @@ void ConfigItems::set_proxy_for2ch_w( const std::string& proxy )
 
     if( regex.exec( "([^/]+:[^/]+@)(.+)$" , proxy, offset, icase, newline, usemigemo, wchar ) )
     {
-        proxy_basicauth_for2ch_w = regex.str( 1 ).substr( 0, regex.str( 1 ).length() - 1 );
+        proxy_basicauth_for2ch_w = regex.str( 1 ).substr( 0, regex.length( 1 ) - 1 );
         proxy_for2ch_w = regex.str( 2 );
     }
 }
@@ -1162,7 +1162,7 @@ void ConfigItems::set_proxy_for_data( const std::string& proxy )
 
     if( regex.exec( "([^/]+:[^/]+@)(.+)$" , proxy, offset, icase, newline, usemigemo, wchar ) )
     {
-        proxy_basicauth_for_data = regex.str( 1 ).substr( 0, regex.str( 1 ).length() - 1 );
+        proxy_basicauth_for_data = regex.str( 1 ).substr( 0, regex.length( 1 ) - 1 );
         proxy_for_data = regex.str( 2 );
     }
 }

--- a/src/control/buttonconfig.cpp
+++ b/src/control/buttonconfig.cpp
@@ -121,9 +121,9 @@ void ButtonConfig::set_one_motion_impl( const int id, const int mode, const std:
 
     if( regex.exec( "(Ctrl)?(\\+?Shift)?(\\+?Alt)?\\+?(.*)", str_motion, offset, icase, newline, usemigemo, wchar ) ){
 
-        if( ! regex.str( 1 ).empty() ) ctrl = true;
-        if( ! regex.str( 2 ).empty() ) shift = true;
-        if( ! regex.str( 3 ).empty() ) alt = true;
+        if( regex.length( 1 ) ) ctrl = true;
+        if( regex.length( 2 ) ) shift = true;
+        if( regex.length( 3 ) ) alt = true;
 
         std::string str_button = regex.str( 4 );
 

--- a/src/control/keyconfig.cpp
+++ b/src/control/keyconfig.cpp
@@ -224,9 +224,9 @@ void KeyConfig::set_one_motion_impl( const int id, const int mode, const std::st
 
     if( regex.exec( "(Ctrl\\+)?(Shift\\+)?(Alt\\+)?(.*)", str_motion, offset, icase, newline, usemigemo, wchar ) ){
 
-        if( ! regex.str( 1 ).empty() ) ctrl = true;
-        if( ! regex.str( 2 ).empty() ) shift = true;
-        if( ! regex.str( 3 ).empty() ) alt = true;
+        if( regex.length( 1 ) ) ctrl = true;
+        if( regex.length( 2 ) ) shift = true;
+        if( regex.length( 3 ) ) alt = true;
 
         const std::string str_key = regex.str( 4 );
         if( str_key.empty() ) return;
@@ -236,7 +236,7 @@ void KeyConfig::set_one_motion_impl( const int id, const int mode, const std::st
         // keyがアスキー文字の場合は shift を無視する (大文字除く)
         // Control::key_press() も参照せよ
         if( CONTROL::is_ascii( key ) ){
-            if( regex.str( 4 ).length() == 1 && key >= 'A' && key <= 'Z' ) shift = true;
+            if( regex.length( 4 ) == 1 && key >= 'A' && key <= 'Z' ) shift = true;
             else shift = false;
         }
     }

--- a/src/dbtree/boardbase.cpp
+++ b/src/dbtree/boardbase.cpp
@@ -623,7 +623,7 @@ std::string BoardBase::url_dat( const std::string& url, int& num_from, int& num_
 
         id = regex.str( 2 ) + get_ext(); 
 
-        if( !regex.str( 3 ).empty() ){ // l50
+        if( regex.length( 3 ) ){ // l50
             num_from = 1;
             num_to = 50;
         }
@@ -638,7 +638,7 @@ std::string BoardBase::url_dat( const std::string& url, int& num_from, int& num_
             num_from = MAX( 1, num_from );
 
             // 12- みたいな場合はとりあえず大きい数字を入れとく
-            if( !regex.str( 5 ).empty() && !num_to ) num_to = CONFIG::get_max_resnumber() + 1;
+            if( regex.length( 5 ) && !num_to ) num_to = CONFIG::get_max_resnumber() + 1;
         }
 
         // -15 みたいな場合
@@ -1826,7 +1826,7 @@ void BoardBase::set_local_proxy( const std::string& proxy )
 
     if( regex.exec( "([^/]+:[^/]+@)(.+)$" , proxy, offset, icase, newline, usemigemo, wchar ) )
     {
-        m_local_proxy_basicauth = regex.str( 1 ).substr( 0, regex.str( 1 ).length() - 1 );
+        m_local_proxy_basicauth = regex.str( 1 ).substr( 0, regex.length( 1 ) - 1 );
         m_local_proxy = regex.str( 2 );
     }
 }
@@ -1851,7 +1851,7 @@ void BoardBase::set_local_proxy_w( const std::string& proxy )
 
     if( regex.exec( "([^/]+:[^/]+@)(.+)$" , proxy, offset, icase, newline, usemigemo, wchar ) )
     {
-        m_local_proxy_basicauth_w = regex.str( 1 ).substr( 0, regex.str( 1 ).length() - 1 );
+        m_local_proxy_basicauth_w = regex.str( 1 ).substr( 0, regex.length( 1 ) - 1 );
         m_local_proxy_w = regex.str( 2 );
     }
 }

--- a/src/dbtree/boardbase.h
+++ b/src/dbtree/boardbase.h
@@ -6,6 +6,7 @@
 #ifndef _BOARDBASE_H
 #define _BOARDBASE_H
 
+#include "jdlib/jdregex.h"
 #include "skeleton/loadable.h"
 
 #include <string>
@@ -121,9 +122,9 @@ namespace DBTREE
         std::string m_name; // 板名
 
         // dat型のurlに変換する時のquery ( url_dat()で使用する )
-        std::string m_query_dat;
-        std::string m_query_cgi;
-        std::string m_query_kako;
+        JDLIB::RegexPattern m_query_dat;
+        JDLIB::RegexPattern m_query_cgi;
+        JDLIB::RegexPattern m_query_kako;
 
         // ローカルあぼーん情報(板内の全レス対象)
         std::list< std::string > m_list_abone_id; // あぼーんするID

--- a/src/dbtree/boardmachi.cpp
+++ b/src/dbtree/boardmachi.cpp
@@ -142,11 +142,11 @@ std::string BoardMachi::url_dat( const std::string& url, int& num_from, int& num
     if( regex.exec( query_dat , url, offset, icase, newline, usemigemo, wchar ) ){
         id = regex.str( 2 );
 
-        if( ! regex.str( 5 ).empty() ){
+        if( regex.length( 5 ) ){
             num_from = atoi( regex.str( 5 ).c_str() );
             num_str = std::to_string( num_from );
         }
-        if( ! regex.str( 7 ).empty() ){
+        if( regex.length( 7 ) ){
             num_to = atoi( regex.str( 7 ).c_str() );
             num_str += "-" + std::to_string( num_to );
         }

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -14,6 +14,7 @@
 
 #include "jdlib/heap.h"
 #include "jdlib/miscutil.h"
+#include "jdlib/jdregex.h"
 
 #include <map>
 #include <cstring>
@@ -83,15 +84,15 @@ namespace DBTREE
         std::list< std::string > m_list_abone_id;   // あぼーんするID
         std::list< std::string > m_list_abone_name; // あぼーんする名前
         std::list< std::string > m_list_abone_word; // あぼーんする文字列
-        std::list< std::string > m_list_abone_regex; // あぼーんする正規表現
+        std::list< JDLIB::RegexPattern > m_list_abone_regex; // あぼーんする正規表現
 
         std::list< std::string > m_list_abone_id_board;   // あぼーんするID(板レベル)
         std::list< std::string > m_list_abone_name_board; // あぼーんする名前(板レベル)
         std::list< std::string > m_list_abone_word_board; // あぼーんする文字列(板レベル)
-        std::list< std::string > m_list_abone_regex_board; // あぼーんする正規表現(板レベル)
+        std::list< JDLIB::RegexPattern > m_list_abone_regex_board; // あぼーんする正規表現(板レベル)
 
         std::list< std::string > m_list_abone_word_global; // あぼーんする文字列(全体)
-        std::list< std::string > m_list_abone_regex_global; // あぼーんする正規表現(全体)
+        std::list< JDLIB::RegexPattern > m_list_abone_regex_global; // あぼーんする正規表現(全体)
         std::unordered_set< int > m_abone_reses; // レスあぼーん情報
         bool m_abone_transparent; // 透明あぼーん
         bool m_abone_chain; // 連鎖あぼーん
@@ -124,7 +125,7 @@ namespace DBTREE
         NODE* m_node_previous;
 
         // AA判定用
-        std::string m_aa_regex;
+        JDLIB::RegexPattern m_aa_regex;
 
         // その他のエラーメッセージ
         std::string m_ext_err;

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -1117,7 +1117,7 @@ void Root::load_etc()
             // basic認証
             if( regex.exec( "https?://([^/]+:[^/]+@)(.+)$" , info.url, offset, icase, newline, usemigemo, wchar ) )
             {
-                info.basicauth = regex.str( 1 ).substr( 0, regex.str( 1 ).length() - 1 );
+                info.basicauth = regex.str( 1 ).substr( 0, regex.length( 1 ) - 1 );
                 info.url = ( info.url[4] == 's' ? "https://" : "http://" ) + regex.str( 2 );
             }
 

--- a/src/jdlib/cookiemanager.cpp
+++ b/src/jdlib/cookiemanager.cpp
@@ -123,7 +123,7 @@ bool SimpleCookieParser::parse( const std::string& input, SimpleCookie& result )
     if( regex.exec( R"-(([^"\=;]+)=([^"\=;]*))-", input, offset, icase, newline, usemigemo, wchar ) ) {
         result.name = regex.str( 1 );
         result.value = regex.str( 0 );
-        offset = regex.str( 0 ).size();
+        offset = regex.length( 0 );
     }
     else {
         return false;
@@ -131,7 +131,7 @@ bool SimpleCookieParser::parse( const std::string& input, SimpleCookie& result )
 
     if( regex.exec( R"-(path=/([^;]+))-", input, offset, icase, newline, usemigemo, wchar ) ) {
         // ルート(/)以外のpathは解析失敗にする
-        if( ! regex.str( 1 ).empty() ) return false;
+        if( regex.length( 1 ) ) return false;
     }
     if( regex.exec( R"-(domain=([^;]+))-", input, offset, icase, newline, usemigemo, wchar ) ) {
         result.domain = regex.str( 1 );

--- a/src/jdlib/jdregex.cpp
+++ b/src/jdlib/jdregex.cpp
@@ -19,45 +19,86 @@ constexpr std::size_t REGEX_MAX_NMATCH = 32;
 
 using namespace JDLIB;
 
-
-Regex::~Regex()
+RegexPattern::RegexPattern( const std::string& reg, const bool icase, const bool newline,
+                            const bool usemigemo, const bool wchar )
 {
-    dispose();
+    set( reg, icase, newline, usemigemo, wchar );
 }
 
 
-void Regex::dispose()
+RegexPattern::~RegexPattern() noexcept
+{
+    clear();
+}
+
+
+RegexPattern::RegexPattern( RegexPattern&& other ) noexcept
+    : m_regex{ other.m_regex }
+    , m_compiled{ other.m_compiled }
+    , m_newline{ other.m_newline }
+    , m_wchar{ other.m_wchar }
+    , m_error{ other.m_error }
+{
+    other.m_compiled = false;
+    other.m_error = decltype( m_error ){};
+}
+
+
+RegexPattern& RegexPattern::operator=( RegexPattern&& other ) noexcept
+{
+    if( this != &other ) {
+        clear();
+
+        m_regex = other.m_regex;
+        m_compiled = other.m_compiled;
+        m_newline = other.m_newline;
+        m_wchar = other.m_wchar;
+        m_error = other.m_error;
+
+        other.m_compiled = false;
+        other.m_error = decltype( m_error ){};
+    }
+    return *this;
+}
+
+
+void RegexPattern::clear()
 {
     if ( m_compiled ) {
 #ifdef POSIX_STYLE_REGEX_API
-        regfree( &m_reg );
+        regfree( &m_regex );
 #else
-        g_regex_unref( m_reg );
-        m_reg = nullptr;
+        g_regex_unref( m_regex );
+        m_regex = nullptr;
 #endif
-        m_compiled = false;
     }
-}
+    m_compiled = false;
 
+#ifdef POSIX_STYLE_REGEX_API
+    m_error = 0;
+#else
+    g_clear_error( &m_error );
+#endif
+}
 
 // icase : 大文字小文字区別しない
 // newline :  . に改行をマッチさせない
 // usemigemo : migemo使用 (コンパイルオプションで指定する必要あり)
 // wchar : 全角半角の区別をしない
-bool Regex::compile( const std::string& reg, const bool icase, const bool newline, const bool use_migemo, const bool wchar )
+bool RegexPattern::set( const std::string& reg, const bool icase, const bool newline,
+                        const bool usemigemo, const bool wchar )
 {
 #ifdef _DEBUG
     if( wchar ){
-        std::cout << "Regex::compile\n";
-        std::cout << reg << std::endl;
+        std::cout << "RegexPattern::set " << reg << std::endl;
     }
 #endif
 
-    dispose();
+    clear();
 
     if( reg.empty() ) return false;
 
-#if POSIX_STYLE_REGEX_API
+#ifdef POSIX_STYLE_REGEX_API
     int cflags = REG_EXTENDED;
     if( newline ) cflags |= REG_NEWLINE;
     if( icase ) cflags |= REG_ICASE;
@@ -72,29 +113,25 @@ bool Regex::compile( const std::string& reg, const bool icase, const bool newlin
     m_wchar = wchar;
 
     const char* asc_reg = reg.c_str();
+    std::string target_asc;
 
     // 全角英数字 → 半角英数字、半角カナ → 全角カナ
     if( m_wchar && MISC::has_widechar( asc_reg ) ){
 
-        m_target_asc.clear();
-        m_table_pos.clear();
-        if( m_target_asc.capacity() < MAX_TARGET_SIZE ) {
-            m_target_asc.reserve( MAX_TARGET_SIZE );
-            m_table_pos.reserve( MAX_TARGET_SIZE );
-        }
-
-        MISC::asc( asc_reg, m_target_asc, m_table_pos );
-        asc_reg = m_target_asc.c_str();
+        target_asc.reserve( MAX_TARGET_SIZE );
+        std::vector<int> temp;
+        MISC::asc( asc_reg, target_asc, temp );
+        asc_reg = target_asc.c_str();
 
 #ifdef _DEBUG
-        std::cout << m_target_asc << std::endl;
+        std::cout << target_asc << std::endl;
 #endif
     }
 
 #ifdef HAVE_MIGEMO_H
     std::string migemo_regex;
 
-    if( use_migemo ){
+    if( usemigemo ) {
 
         migemo_regex = jdmigemo::convert( asc_reg );
         if( ! migemo_regex.empty() ) {
@@ -104,13 +141,14 @@ bool Regex::compile( const std::string& reg, const bool icase, const bool newlin
 #endif
 
 #ifdef POSIX_STYLE_REGEX_API
-    if( regcomp( &m_reg, asc_reg, cflags ) != 0 ){
-        regfree( &m_reg );
+    m_error = regcomp( &m_regex, asc_reg, cflags );
+    if( m_error != 0 ) {
+        regfree( &m_regex );
         return false;
     }
 #else
-    m_reg = g_regex_new( asc_reg, GRegexCompileFlags( cflags ), GRegexMatchFlags( 0 ), nullptr );
-    if( m_reg == nullptr ){
+    m_regex = g_regex_new( asc_reg, GRegexCompileFlags( cflags ), GRegexMatchFlags( 0 ), &m_error );
+    if( ! m_regex ) {
         return false;
     }
 #endif
@@ -120,37 +158,74 @@ bool Regex::compile( const std::string& reg, const bool icase, const bool newlin
 }
 
 
-bool Regex::exec( const std::string& target, const size_t offset )
+std::string RegexPattern::errstr() const
 {
-    if ( ! m_compiled ) return false;
+    std::string errmsg;
 
-    if( target.empty() ) return false;
-    if( target.length() <= offset ) return false;
+#ifdef POSIX_STYLE_REGEX_API
+    switch( m_error ) {
+        case 0: errmsg = "エラーはありません。"; break;
+        case REG_BADBR: errmsg = "無効な後方参照オペレータを使用しています。"; break;
+        case REG_BADPAT: errmsg = "無効なグループやリストなどを使用しています。"; break;
+        case REG_BADRPT: errmsg = "'*' が最初の文字としてくるような、無効な繰り返しオペレータを使用しています。"; break;
+        case REG_EBRACE: errmsg = "インターバルオペレータ {} が閉じていません。"; break;
+        case REG_EBRACK: errmsg = "リストオペレータ [] が閉じていません。"; break;
+        case REG_ECOLLATE: errmsg = "照合順序の要素として有効ではありません。"; break;
+        case REG_ECTYPE: errmsg = "未知のキャラクタークラス名です。"; break;
+#ifdef HAVE_REGEX_H
+        case REG_EEND: errmsg = "未定義エラー。POSIX.2 には定義されていません。"; break;
+#endif
+        case REG_EESCAPE: errmsg = "正規表現がバックスラッシュで終っています。"; break;
+        case REG_EPAREN: errmsg = "グループオペレータ () が閉じていません。"; break;
+        case REG_ERANGE: errmsg = "無効な範囲オペレータを使用しています。"; break;
+#ifndef HAVE_ONIGPOSIX_H
+        case REG_ESIZE: errmsg = "複雑過ぎる正規表現です。POSIX.2 には定義されていません。"; break;
+#endif
+        case REG_ESPACE: errmsg = "regex ルーチンがメモリーを使い果たしました。"; break;
+        case REG_ESUBREG: errmsg = "サブエクスプレッション (...) への無効な後方参照です。"; break;
+        default: errmsg = "未知のエラーが発生しました。"; break;
+    }
+#else
+    if( m_error ) {
+        errmsg = m_error->message;
+    }
+#endif
+    return errmsg;
+}
 
+
+///////////////////////////////////////////////
+
+
+bool Regex::match( const RegexPattern& creg, const std::string& target,
+                   const std::size_t offset, const bool notbol, const bool noteol )
+{
     m_pos.clear();
     m_results.clear();
+    m_target_asc.clear();
+    m_table_pos.clear();
+
+    if ( ! creg.m_compiled ) return false;
+
+    if( target.empty() ) return false;
+    if( target.size() <= offset ) return false;
 
     const char* asc_target = target.c_str() + offset;
 
-    bool exec_asc = false;
-
     // 全角英数字 → 半角英数字、半角カナ → 全角カナ
-    if( m_wchar && MISC::has_widechar( asc_target ) ){
+    if( creg.m_wchar && MISC::has_widechar( asc_target ) ) {
 
 #ifdef _DEBUG
-        std::cout << "Regex::exec offset = " << offset << std::endl;
+        std::cout << "Regex::match offset = " << offset << std::endl;
         std::cout << target << std::endl;
 #endif
 
-        m_target_asc.clear();
-        m_table_pos.clear();
         if( m_target_asc.capacity() < MAX_TARGET_SIZE ) {
             m_target_asc.reserve( MAX_TARGET_SIZE );
             m_table_pos.reserve( MAX_TARGET_SIZE );
         }
 
         MISC::asc( asc_target, m_target_asc, m_table_pos );
-        exec_asc = true;
         asc_target = m_target_asc.c_str();
 
 #ifdef _DEBUG
@@ -163,7 +238,7 @@ bool Regex::exec( const std::string& target, const size_t offset )
 
     // 鬼車はnewlineを無視するようなので、文字列のコピーを取って
     // 改行をスペースにしてから実行する
-    if( ! m_newline ){
+    if( ! creg.m_newline ) {
         target_copy = asc_target;
         std::replace( target_copy.begin(), target_copy.end(), '\n', ' ' );
         asc_target = target_copy.c_str();
@@ -172,17 +247,25 @@ bool Regex::exec( const std::string& target, const size_t offset )
 
 #ifdef POSIX_STYLE_REGEX_API
     regmatch_t pmatch[ REGEX_MAX_NMATCH ]{};
+
+    int eflags = 0;
+    if( notbol ) eflags |= REG_NOTBOL;
+    if( noteol ) eflags |= REG_NOTEOL;
 #else
     GMatchInfo* pmatch{};
+
+    int eflags = 0;
+    if( notbol ) eflags |= G_REGEX_MATCH_NOTBOL;
+    if( noteol ) eflags |= G_REGEX_MATCH_NOTEOL;
 #endif
 
 #ifdef POSIX_STYLE_REGEX_API
-    if( regexec( &m_reg, asc_target, REGEX_MAX_NMATCH, pmatch, 0 ) != 0 ){
+    if( regexec( &creg.m_regex, asc_target, REGEX_MAX_NMATCH, pmatch, eflags ) != 0 ) {
         return false;
     }
     constexpr int match_count = REGEX_MAX_NMATCH;
 #else
-    if( ! g_regex_match( m_reg, asc_target, GRegexMatchFlags( 0 ), &pmatch ) ){
+    if( ! g_regex_match( creg.m_regex, asc_target, GRegexMatchFlags( eflags ), &pmatch ) ) {
         g_match_info_free( pmatch );
         return false;
     }
@@ -200,23 +283,30 @@ bool Regex::exec( const std::string& target, const size_t offset )
         if( ! g_match_info_fetch_pos( pmatch, i, &so, &eo ) ) so = eo = -1;
 #endif
 
-        if( exec_asc && so >= 0 && eo >= 0 ){
-#ifdef _DEBUG
-            std::cout << "so = " << so << " eo = " << eo;
-#endif
-            so = m_table_pos[ so ];
-            eo = m_table_pos[ eo ];
-#ifdef _DEBUG
-            std::cout << " -> so = " << so << " eo = " << eo << std::endl;
-#endif
+        if( so < 0 || eo < 0 ) {
+            m_pos.push_back( so );
+            m_results.push_back( std::string() );
         }
-        so += offset;
-        eo += offset;
 
-        m_pos.push_back( so );
+        else {
+            if( ! m_table_pos.empty() ) {
+#ifdef _DEBUG
+                std::cout << "so=" << so << " eo=" << eo;
+#endif
+                while( so > 0 && m_table_pos[so] < 0 ) so--;
+                so = m_table_pos[so];
+                auto it = std::find_if( m_table_pos.cbegin() + eo, m_table_pos.cend(), []( int p ) { return p >= 0; } );
+                eo = ( it != m_table_pos.cend() ) ? *it : m_table_pos.size();
+#ifdef _DEBUG
+                std::cout << " -> so=" << so << " eo=" << eo << std::endl;
+#endif
+            }
+            so += offset;
+            eo += offset;
 
-        if( so >= 0 && eo >= 0 ) m_results.push_back( target.substr( so, eo - so ) );
-        else m_results.push_back( std::string() );
+            m_pos.push_back( so );
+            m_results.push_back( target.substr( so, eo - so ) );
+        }
     }
 
 #ifndef POSIX_STYLE_REGEX_API
@@ -227,37 +317,46 @@ bool Regex::exec( const std::string& target, const size_t offset )
 }
 
 
-// icase : 大文字小文字区別しない
-// newline :  . に改行をマッチさせない
-// usemigemo : migemo使用 (コンパイルオプションで指定する必要あり)
-// wchar : 全角半角の区別をしない
-bool Regex::exec( const std::string& reg, const std::string& target,
-                  const size_t offset, const bool icase, const bool newline, const bool use_migemo, const bool wchar )
+//
+// マッチした文字列と $0〜$9 or \0〜\9 を置換する
+//
+std::string Regex::replace( const std::string& repstr ) const
 {
-    if ( ! compile(reg, icase, newline, use_migemo, wchar ) ) return false;
+    if( repstr.empty() ) return repstr;
 
-    if ( ! exec(target, offset) ){
-        dispose();
-        return false;
+    const char* p0 = repstr.c_str();
+    const char* p1;
+    std::string str_out;
+
+    while( ( p1 = strchr( p0, '\\' ) ) != nullptr ) {
+        int n = p1[1] - '0';
+        str_out.append( p0, p1 - p0 );
+        p0 = p1 + 2;
+        if( n < 0 || n > 9 ) {
+            str_out.push_back( p1[1] );
+        }
+        else if( m_results.size() > static_cast<std::size_t>( n ) && m_pos[n] != -1 ){
+            str_out.append( m_results[n] );
+        }
     }
-    
-    dispose();
-    
-    return true;
+
+    str_out.append( repstr, p0 - repstr.c_str(), std::string::npos );
+
+    return str_out;
 }
 
 
-std::string Regex::str( const size_t num )
+std::string Regex::str( std::size_t num ) const
 {
-    if( m_results.size() > num  ) return m_results[ num ];
+    if( m_results.size() > num ) return m_results[num];
 
-    return std::string();
+    return {};
 }
 
 
-int Regex::pos( const size_t num )
+int Regex::pos( std::size_t num ) const noexcept
 {
-    if( m_results.size() > num ) return m_pos[ num ];
+    if( m_results.size() > num ) return m_pos[num];
 
     return -1;
 }

--- a/src/jdlib/jdregex.cpp
+++ b/src/jdlib/jdregex.cpp
@@ -346,11 +346,11 @@ std::string Regex::replace( const std::string& repstr ) const
 }
 
 
-std::string Regex::str( std::size_t num ) const
+int Regex::length( std::size_t num ) const noexcept
 {
-    if( m_results.size() > num ) return m_results[num];
+    if( m_results.size() > num ) return m_results[num].size();
 
-    return {};
+    return 0;
 }
 
 
@@ -359,4 +359,12 @@ int Regex::pos( std::size_t num ) const noexcept
     if( m_results.size() > num ) return m_pos[num];
 
     return -1;
+}
+
+
+std::string Regex::str( std::size_t num ) const
+{
+    if( m_results.size() > num ) return m_results[num];
+
+    return {};
 }

--- a/src/jdlib/jdregex.h
+++ b/src/jdlib/jdregex.h
@@ -102,6 +102,7 @@ namespace JDLIB
         // マッチした文字列と \0〜\9 を置換する
         std::string replace( const std::string& repstr ) const;
 
+        int length( std::size_t num ) const noexcept;
         int pos( std::size_t num ) const noexcept;
         std::string str( std::size_t num ) const;
     };

--- a/src/jdlib/jdregex.h
+++ b/src/jdlib/jdregex.h
@@ -25,46 +25,85 @@
 
 namespace JDLIB
 {
-    class Regex
+    class Regex;
+
+    class RegexPattern
     {
-        std::vector< int > m_pos;
-        std::vector< std::string > m_results;
+        friend class Regex;
 
 #ifdef POSIX_STYLE_REGEX_API
-        regex_t m_reg;
+        // onigurumaではregexec()の引数regex_t*がconst修飾されていない
+        // そのためRegex::match()のコンパイルエラーを回避するためmutable修飾が必要
+        mutable regex_t m_regex;
 #else
-        GRegex* m_reg{};
+        GRegex* m_regex{};
 #endif
-
         bool m_compiled{};
         bool m_newline{};
         bool m_wchar{};
+#ifdef POSIX_STYLE_REGEX_API
+        int m_error{};
+#else
+        GError *m_error{};
+#endif
+
+    public:
+        RegexPattern() noexcept = default;
+        RegexPattern( const std::string& reg, const bool icase, const bool newline,
+                      const bool usemigemo = false, const bool wchar = false );
+        ~RegexPattern() noexcept;
+
+        // regex_tを複製する方法がないためcopy禁止にする
+        RegexPattern( const RegexPattern& ) = delete;
+        RegexPattern& operator=( const RegexPattern& ) = delete;
+        // moveは許可
+        RegexPattern( RegexPattern&& ) noexcept;
+        RegexPattern& operator=( RegexPattern&& ) noexcept;
+
+        bool set( const std::string& reg, const bool icase, const bool newline,
+                  const bool usemigemo = false, const bool wchar = false );
+        void clear();
+        bool compiled() const noexcept { return m_compiled; }
+        std::string errstr() const;
+    };
+
+
+    class Regex
+    {
+        std::vector<int> m_pos;
+        std::vector<std::string> m_results;
 
         // 全角半角を区別しないときに使う変換用バッファ
         // 処理可能なバッファ長は regoff_t (= int) のサイズに制限される
         std::string m_target_asc;
-        std::vector< int > m_table_pos;
+        std::vector<int> m_table_pos;
 
     public:
 
-        Regex() = default;
-        ~Regex();
+        Regex() noexcept = default;
+        ~Regex() noexcept = default;
 
-        void dispose();
-        
+        // notbol : 行頭マッチは必ず失敗する
+        // noteol : 行末マッチは必ず失敗する
+        bool match( const RegexPattern& creg, const std::string& target, const std::size_t offset,
+                    const bool notbol = false, const bool noteol = false );
+
         // icase : 大文字小文字区別しない
         // newline :  . に改行をマッチさせない
         // usemigemo : migemo使用 (コンパイルオプションで指定する必要あり)
         // wchar : 全角半角の区別をしない
-        bool compile( const std::string& reg, const bool icase, const bool newline, const bool usemigemo,
-                      const bool wchar );
+        bool exec( const std::string& reg, const std::string& target, const std::size_t offset,
+                   const bool icase, const bool newline, const bool usemigemo = false,
+                   const bool wchar = false ) {
+            RegexPattern pattern( reg, icase, newline, usemigemo, wchar );
+            return match( pattern, target, offset );
+        }
 
-        bool exec( const std::string& target, const size_t offset );
-        bool exec( const std::string& reg, const std::string& target, const size_t offset, const bool icase,
-                   const bool newline, const bool usemigemo, const bool wchar );
+        // マッチした文字列と \0〜\9 を置換する
+        std::string replace( const std::string& repstr ) const;
 
-        int pos( const size_t num );
-        std::string str( const size_t num );
+        int pos( std::size_t num ) const noexcept;
+        std::string str( std::size_t num ) const;
     };
 }
 

--- a/src/jdlib/miscutil.cpp
+++ b/src/jdlib/miscutil.cpp
@@ -1884,6 +1884,7 @@ bool MISC::starts_with( const char* self, const char* starts )
 std::vector<MISC::FormDatum> MISC::parse_html_form_data( const std::string& html )
 {
     JDLIB::Regex regex;
+    JDLIB::RegexPattern pat;
     constexpr bool icase = true; // 大文字小文字区別しない
     constexpr bool newline = false;  // . に改行をマッチさせる
     constexpr bool usemigemo = false;
@@ -1891,14 +1892,14 @@ std::vector<MISC::FormDatum> MISC::parse_html_form_data( const std::string& html
 
     // <input type=(hidden|submit)> or <textarea> のタグを解析して name と value を取得
     const std::string pattern = R"((<input +type=("hidden"|hidden|"submit"|submit) +(name=([^ ]*) +value=([^>]*)|value=([^ ]*) +name=([^>]*))>|<textarea +name=([^ >]*)[^>]*>(.*?)</textarea>))";
-    regex.compile( pattern, icase, newline, usemigemo, wchar );
+    pat.set( pattern, icase, newline, usemigemo, wchar );
 
     std::vector<MISC::FormDatum> data;
     for( std::size_t offset = 0; ; ++offset){
         std::string name;
         std::string value;
 
-        if( regex.exec( html, offset ) ) {
+        if( regex.match( pat, html, offset ) ) {
             const std::string name_value = MISC::tolower_str( regex.str( 3 ) );
             if( name_value.compare( 0, 5, "name=" ) == 0 ) {
                 name = MISC::remove_space( regex.str( 4 ) );

--- a/src/linkfiltermanager.cpp
+++ b/src/linkfiltermanager.cpp
@@ -149,15 +149,7 @@ bool Linkfilter_Manager::exec( const std::string& url, const std::string& link, 
         if( ! regex.exec( query, link, offset, icase, newline, usemigemo, wchar ) ) continue;
 
         // \0 ... \9 までのcmd文字列を置換
-        std::string cmd_out = cmd;
-        char rep_text[] = "\\0";
-        for( int i = 0; i < 9; i++ ){
-            if( regex.pos( i ) == -1 ){
-                continue;
-            }
-            rep_text[ 1 ] = '0' + i;
-            cmd_out = MISC::replace_str( cmd_out, rep_text, regex.str( i ) );
-        }
+        const std::string cmd_out = regex.replace( cmd );
 
         // queryと一致したら実行
         CORE::get_usrcmd_manager()->exec( cmd_out, url, link, selection, 0 );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -394,10 +394,10 @@ int main( int argc, char **argv )
                 query = "(([0-9]*)x([0-9]*))?\\-([0-9]*)\\+([0-9]*)";
                 if( regex.exec( query, optarg, offset, icase, newline, usemigemo, wchar ) ){
 
-                    if( ! regex.str( 2 ).empty() ) init_w = atoi( regex.str( 2 ).c_str() );
-                    if( ! regex.str( 3 ).empty() ) init_h = atoi( regex.str( 3 ).c_str() );
-                    if( ! regex.str( 4 ).empty() ) init_x = atoi( regex.str( 4 ).c_str() );
-                    if( ! regex.str( 5 ).empty() ) init_y = atoi( regex.str( 5 ).c_str() );
+                    if( regex.length( 2 ) ) init_w = atoi( regex.str( 2 ).c_str() );
+                    if( regex.length( 3 ) ) init_h = atoi( regex.str( 3 ).c_str() );
+                    if( regex.length( 4 ) ) init_x = atoi( regex.str( 4 ).c_str() );
+                    if( regex.length( 5 ) ) init_y = atoi( regex.str( 5 ).c_str() );
                 }
                 else usage( EXIT_FAILURE );
 

--- a/src/searchmanager.cpp
+++ b/src/searchmanager.cpp
@@ -288,7 +288,7 @@ void Search_Manager::search_fin_title()
             }
 
             // オフセットを設定して再検索する
-            offset = regex.pos( 0 ) + regex.str( 0 ).length();
+            offset = regex.pos( 0 ) + regex.length( 0 );
         }
     }
 

--- a/src/searchmanager.cpp
+++ b/src/searchmanager.cpp
@@ -261,10 +261,10 @@ void Search_Manager::search_fin_title()
         const bool newline = true;
         const bool usemigemo = false;
         const bool wchar = false;
-        regex.compile( pattern, icase, newline, usemigemo, wchar );
+        const JDLIB::RegexPattern regexptn( pattern, icase, newline, usemigemo, wchar );
 
         std::size_t offset = 0;
-        while( regex.exec( source, offset ) ){
+        while( regex.match( regexptn, source, offset ) ){
 
             SEARCHDATA data;
             data.url_readcgi = DBTREE::url_readcgi( regex.str( 1 ), 0, 0 );

--- a/src/urlreplacemanager.h
+++ b/src/urlreplacemanager.h
@@ -3,11 +3,11 @@
 #ifndef _URLREPLACEMANAGER_H
 #define _URLREPLACEMANAGER_H
 
-#include <string>
-#include <list>
-#include <map>
-
 #include "jdlib/jdregex.h"
+
+#include <string>
+#include <vector>
+
 
 namespace CORE
 {
@@ -24,7 +24,7 @@ namespace CORE
 
     struct UrlreplaceItem
     {
-        std::string match;
+        JDLIB::RegexPattern creg;
         std::string replace;
         std::string referer;
         int imgctrl;
@@ -33,8 +33,7 @@ namespace CORE
 
     class Urlreplace_Manager
     {
-        std::list< UrlreplaceItem > m_list_cmd;
-        std::map< std::string, int > m_map_imgctrl; // 画像コントロールのキャッシュ
+        std::vector<UrlreplaceItem> m_list_cmd;
 
       public:
 
@@ -45,7 +44,7 @@ namespace CORE
         bool exec( std::string& url );
 
         // URLからリファラを求める
-        bool referer( const std::string& url, std::string& referer );
+        bool referer( const std::string& url, std::string& refstr );
 
         // URLの画像コントロールを取得する
         int get_imgctrl( const std::string& url );
@@ -53,10 +52,6 @@ namespace CORE
       private:
 
         void conf2list( const std::string& conf );
-        int get_imgctrl_impl( const std::string& url );
-
-        // 置換文字列を変換
-        void replace( JDLIB::Regex& regex, std::string& str );
     };
 
     ///////////////////////////////////////


### PR DESCRIPTION
**このPRはアイデア検証用でありマージしません。**

正規表現クラスとクライアント側のコードを更新します。

- `RegexPattern`クラスを導入してコンパイル済みの正規表現オブジェクトと検索実行してマッチ結果を保持する`Regex`クラスに分割します。
- 正規表現のコンパイルや検索に失敗したときエラー内容をテキストで取得できるようにします。
- 検索実行時に行頭行末にマッチさせないオプションを追加します。
- マッチ結果を使って文字列を置換するメンバー関数を追加します。

---
### パッチの適応方法

#### ~~git clone コマンドを使う方法 (一時的なcloneで使い捨てる)~~

```
git clone -b idea-improve-regex-class --depth 1 https://github.com/ma8ma/JDim.git temp
cd temp

meson debugdir
meson compile -C debugdir

# 実行
./debugdir/src/jdim

# パッチの削除
cd ../
rm -rf temp
```

#### curl と patch コマンドを使う場合
※ git pullなどでmasterブランチを更新してから行うことを推奨します。

```
git chechout master
git pull
curl -L https://github.com/ma8ma/JDim/pull/53.patch | patch -p1
meson debugdir
meson compile -C debugdir

# 実行
./debugdir/src/jdim

# パッチの削除
rm -rf debugdir
git reset --hard master
```

#### [hub コマンド][hub]を使う場合

```
hub checkout https://github.com/ma8ma/JDim/pull/53
meson debugdir
meson compile -C debugdir

# 実行
./debugdir/src/jdim

# パッチの削除
rm -rf debugdir
git checkout master
git branch -D idea-improve-regex-class
```

[hub]: https://hub.github.com/

