### PR TITLE
[IDEA] Imageviewbase update menu construction

### DIFF
--- a/src/image/imageview.cpp
+++ b/src/image/imageview.cpp
@@ -408,8 +408,13 @@ void ImageViewMain::add_tab_number()
 //
 Gtk::Menu* ImageViewMain::get_popupmenu( const std::string& url )
 {
-    Gtk::Menu* popupmenu = dynamic_cast< Gtk::Menu* >( ui_manager()->get_widget( "/popup_menu" ) );
-    return popupmenu;
+    // 初回の呼び出し時にメニューモデルをバインドする
+    if( ! m_popup_menu.get_attach_widget() ) {
+        auto menumodel = Glib::RefPtr<Gio::MenuModel>::cast_dynamic( m_builder->get_object( "popup_menu" ) );
+        m_popup_menu.bind_model( menumodel, true );
+        m_popup_menu.attach_to_widget( *this );
+    }
+    return &m_popup_menu;
 }
 
 

--- a/src/image/imageview.h
+++ b/src/image/imageview.h
@@ -31,6 +31,8 @@ namespace IMAGE
         bool m_do_resizing{};
         bool m_scrolled{};
 
+        Gtk::Menu m_popup_menu;
+
       public:
         explicit ImageViewMain( const std::string& url );
         ~ImageViewMain();

--- a/src/image/imageviewbase.h
+++ b/src/image/imageviewbase.h
@@ -46,7 +46,11 @@ namespace IMAGE
 
         bool m_enable_menuslot;
 
+        Glib::RefPtr<Gio::SimpleActionGroup> m_action_group;
+
       protected:
+
+        Glib::RefPtr<Gtk::Builder> m_builder;
 
         // Viewが所属するAdminクラス
         SKELETON::Admin* get_admin() override;

--- a/src/image/imageviewicon.h
+++ b/src/image/imageviewicon.h
@@ -16,6 +16,11 @@ namespace IMAGE
         /// 選択されてる画像アイコンの背景色を赤に設定するプロバイダ
         Glib::RefPtr<Gtk::CssProvider> m_provider;
 
+        Gtk::Menu m_popup_menu;
+        Glib::RefPtr<Gio::Menu> m_menumodel;
+        Glib::RefPtr<Gio::MenuItem> m_item_sub;
+        int m_prev_n_tabs; ///< 前回表示したときのタブ数
+
       public:
         explicit ImageViewIcon( const std::string& url );
         ~ImageViewIcon();

--- a/src/image/imageviewpopup.cpp
+++ b/src/image/imageviewpopup.cpp
@@ -322,8 +322,13 @@ void ImageViewPopup::clicked()
 //
 Gtk::Menu* ImageViewPopup::get_popupmenu( const std::string& url )
 {
-    Gtk::Menu* popupmenu = dynamic_cast< Gtk::Menu* >( ui_manager()->get_widget( "/popup_menu_popup" ) );
-    return popupmenu;
+    // 初回の呼び出し時にメニューモデルをバインドする
+    if( ! m_popup_menu.get_attach_widget() ) {
+        auto menumodel = Glib::RefPtr<Gio::MenuModel>::cast_dynamic( m_builder->get_object( "popup_menu_popup" ) );
+        m_popup_menu.bind_model( menumodel, true );
+        m_popup_menu.attach_to_widget( *this );
+    }
+    return &m_popup_menu;
 }
 
 

--- a/src/image/imageviewpopup.h
+++ b/src/image/imageviewpopup.h
@@ -22,6 +22,8 @@ namespace IMAGE
 
         bool m_clicked{};
 
+        Gtk::Menu m_popup_menu;
+
       public:
 
         explicit ImageViewPopup( const std::string& url );

--- a/src/usrcmdmanager.h
+++ b/src/usrcmdmanager.h
@@ -23,6 +23,8 @@ namespace CORE
         int m_size;
 
         std::vector< std::string > m_list_cmd;
+        Glib::RefPtr<Gio::Menu> m_menumodel;
+        bool m_need_rebuild{};
 
     public:
 
@@ -65,14 +67,32 @@ namespace CORE
         std::string create_usrcmd_menu( Glib::RefPtr< Gtk::ActionGroup >& action_group,
                                         const XML::Dom* dom, int& dirno, int& cmdno );
 
+        /// ユーザーコマンドのメニューを初期化して返す
+        Glib::RefPtr<Gio::Menu> get_usrcmd_menu();
+
         Glib::RefPtr< Gtk::Action > get_action( Glib::RefPtr< Gtk::ActionGroup >& action_group, const int num );
+
+        /// ユーザーコマンドのGAction名を返す
+        Glib::ustring get_action_name( const int num ) const;
 
         // 選択不可かどうか判断して visible や sensitive を切り替える
         void toggle_sensitive( Glib::RefPtr< Gtk::ActionGroup >& action_group,
                                const std::string& url_article,
                                const std::string& url_link,
                                const std::string& str_select );
+
+        /// ユーザーコマンドの項目を更新する
+        void update_menu_items( const Glib::RefPtr<Gio::SimpleActionGroup>& action_group,
+                                const std::string& url_article,
+                                const std::string& url_link,
+                                const std::string& str_select,
+                                const std::string& action_scope );
       private:
+
+        /// ユーザコマンドの登録とメニュー作成
+        Glib::RefPtr<Gio::Menu> create_usrcmd_menu( const Glib::ustring& action_scope,
+                                                    const XML::Dom* dom, int& cmdno,
+                                                    const std::vector<int>& hide );
 
         bool show_replacetextdiag( std::string& texti, const std::string& title ) const;
         void set_cmd( const std::string& cmd );


### PR DESCRIPTION
**このPRはアイデア検証用でありマージしません。**

#### [[IDEA] Usrcmd_Manager: Update context menu construction to use Gio::Menu](https://github.com/ma8ma/JDim/commit/7ddf37be933e1e3e7bc6fea49ee79c428fdee117)

ユーザーコマンドのメニュー構築を更新して廃止予定の`GtkAction`や`GtkActionGroup`のかわりに`GAction`、`GSimpleActionGroup`、`GMenu`を使った方法にします。
usrcmdを使うビューをすべて更新するまで従来の関数は削除しません。

#### [[IDEA] ImageViewBase: Update context menu construction to use Gio::Menu](https://github.com/ma8ma/JDim/commit/113a655bcdd0f4fc99060f73bc2b079d0a2854c4)

画像ビューの右クリックメニューの構築を更新して廃止予定の`GtkAction`や`GtkUIManager`のかわりに`GAction`、`GtkBuilder`、`GMenu`を使った方法にします。
合わせて、GTK4で廃止される`GtkMenu`への依存を減らすためメニューラベルにアクセラレーターキーやマウスジェスチャーの表示を追加する処理を削除します。

変更点
- GAction, GMenuではサブメニューを無効化できないためサブメニュー内の項目に対して選択可能か設定する

関連のissue: JDimproved/JDim#977