### PR TITLE
[IDEA] Implement NodeTreeBase::reset_tree()

### DIFF
--- a/src/article/articleview.cpp
+++ b/src/article/articleview.cpp
@@ -696,7 +696,7 @@ void ArticleViewMain::do_relayout( const bool completely )
     int num_reserve = drawarea()->get_goto_num_reserve();
     int separator_new = drawarea()->get_separator_new();
 
-    if( completely ) DBTREE::article_clear_nodetree( url_article() );
+    if( completely ) DBTREE::article_reset_nodetree( url_article() );
 
     drawarea()->clear_screen();
     drawarea()->set_separator_new( separator_new );

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -417,8 +417,8 @@ namespace DBTREE
         // スレッド924か
         bool is_924() const noexcept { return m_924; }
 
-        // NodeTree削除
-        void unlock_impl() override;
+        // NodeTreeの初期化
+        void reset_nodetree();
 
       private:
 
@@ -435,6 +435,7 @@ namespace DBTREE
 
         void slot_node_updated();
         void slot_load_finished();
+        void unlock_impl() override;
 
         // お気に入りのアイコンとスレビューのタブのアイコンに更新マークを表示
         // update == true の時に表示。falseなら戻す

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -1023,10 +1023,10 @@ void DBTREE::article_clear_post_history( const std::string& url )
 }
 
 
-// NodeTree削除
-void DBTREE::article_clear_nodetree( const std::string& url )
+// NodeTreeの初期化
+void DBTREE::article_reset_nodetree( const std::string& url )
 {
-    DBTREE::get_article( url )->unlock_impl();
+    DBTREE::get_article( url )->reset_nodetree();
 }
 
 

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -261,8 +261,8 @@ namespace DBTREE
     void article_update_writetime( const std::string& url );
     size_t article_lng_dat( const std::string& url );
 
-    // NodeTree削除
-    void article_clear_nodetree( const std::string& url );
+    // NodeTreeの初期化
+    void article_reset_nodetree( const std::string& url );
 
     // ユーザーエージェント
     const std::string& get_agent( const std::string& url );   // ダウンロード用

--- a/src/dbtree/nodetree2ch.cpp
+++ b/src/dbtree/nodetree2ch.cpp
@@ -56,6 +56,16 @@ NodeTree2ch::~NodeTree2ch()
 }
 
 
+/**
+ * @brief 一部を除きNodeTreeを初期状態に戻す
+ */
+void NodeTree2ch::reset_tree()
+{
+    NodeTreeBase::reset_tree();
+    m_mode = MODE_NORMAL;
+}
+
+
 //
 // キャッシュに保存する前の前処理
 //

--- a/src/dbtree/nodetree2ch.h
+++ b/src/dbtree/nodetree2ch.h
@@ -26,6 +26,8 @@ namespace DBTREE
                      const std::string& date_modified, time_t since_time );
         ~NodeTree2ch();
 
+        void reset_tree() override;
+
         int get_res_number_max() const noexcept override { return m_res_number_max; }
         std::size_t get_dat_volume_max() const noexcept override { return m_dat_volume_max; }
 

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -36,7 +36,10 @@ namespace DBTREE
 
     constexpr size_t RESUME_CHKSIZE = 64;
 
-    //ノードツリーのベースクラス
+    /** @brief ノードツリーのベースクラス
+     *
+     * @remarks 初期化や初期設定が必要なメンバー変数は`reset_tree()`に処理を追加する。
+     */
     class NodeTreeBase : public SKELETON::Loadable
     {
         typedef sigc::signal< void > SIG_UPDATED;
@@ -145,6 +148,9 @@ namespace DBTREE
 
         NodeTreeBase( const std::string& url, const std::string& date_modified );
         ~NodeTreeBase();
+
+        // 一部を除きNodeTreeを初期状態に戻す
+        virtual void reset_tree();
 
         bool empty() const noexcept { return m_url.empty(); }
         void update_url( const std::string& url );

--- a/src/skeleton/loadable.cpp
+++ b/src/skeleton/loadable.cpp
@@ -124,6 +124,17 @@ void Loadable::stop_load()
 
 
 
+/**
+ * @brief ロードを停止してスレッドが終了するまで待機する
+ */
+void Loadable::stop_load_sync()
+{
+    stop_load();
+    if( m_loader ) m_loader->wait();
+}
+
+
+
 // ローダーからコールバックされてコードなどを取得してから
 // receive_data() を呼び出す
 void Loadable::receive( const char* data, size_t size )

--- a/src/skeleton/loadable.h
+++ b/src/skeleton/loadable.h
@@ -125,6 +125,8 @@ namespace SKELETON
 
         // ロード停止
         virtual void stop_load();
+        // ロードを停止してスレッドが終了するまで待機する
+        void stop_load_sync();
 
         // ロード強制停止
         // loadableを delete する前に terminate_load() を呼び出さないと


### PR DESCRIPTION
**このPRは不採用のアイデアでありマージしません。**

commit d8c12d26c4e0981c3709ff7309adf86a5fa3b5ad
Implement DBTREE::article_clear_nodetree()
スレッドをURLで指定してNodeTreeを削除する関数を実装します。の別案

NodeTreeオブジェクトを削除するかわりにツリー情報をリセットする仕組みを実装します。

### 特徴
- NodeTreeのメンバー変数をコンストラクタ呼び出し後の状態に戻す
- シグナルハンドラは切断しない
- `SKELETON::Loadable::m_date_modified`の値は失われるためNodeTreeを 再利用する前に再設定が必要

### NodeTreeBaseと派生クラスを修正するときの注意
- 初期化や初期設定が必要なメンバー変数を追加したときは`reset_tree()`に 処理を追加する

### 不採用の理由
`NodeTreeBase::unlock_impl()`を呼び出す実装と比較したところ実行時間やメモリ使用量で大きな違いはありませんでした。
そのため実装がよりシンプルな`unlock_impl()`を採用しました。

関連のpull request: JDimproved#1060