### PR TITLE
[IDEA] Add CMakeLists.txt for experimental support (2022-12)

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -10,31 +10,6 @@ on:
 
 jobs:
 
-  ASan-22:
-    runs-on: ubuntu-22.04
-    env:
-      CC: gcc-11
-      CXX: g++-11
-      # Avoid crash for calling crypt_r() that is pointing invalid address.
-      # https://github.com/JDimproved/JDim/issues/943
-      AVOID_CRASH: -Wl,--push-state,--no-as-needed -lcrypt -Wl,--pop-state
-    steps:
-      - uses: actions/checkout@v3
-      - name: dependencies installation
-        run: |
-          sudo apt update
-          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev g++-11
-      - name: meson builddir -Db_sanitize=address,undefined -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dcpp_link_args="${AVOID_CRASH}"
-        run: meson builddir -Db_sanitize=address,undefined -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dcpp_link_args="${AVOID_CRASH}"
-        # `compile` subcommand requires Meson 0.54 or later.
-      - name: ninja -C builddir
-        run: ninja -C builddir
-        # Since Meson 0.57, `test` subcommand will only rebuild test program.
-      - name: meson test -v -C builddir
-        run: meson test -v -C builddir
-      - name: ./builddir/src/jdim -V
-        run: ./builddir/src/jdim -V
-
   compiler-20:
     runs-on: ubuntu-20.04
     env:
@@ -69,15 +44,15 @@ jobs:
       - name: dependencies installation
         run: |
           sudo apt update
-          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev ${{ matrix.sets.package }}
-      - name: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
-        run: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
-      - name: ninja -C builddir
-        run: ninja -C builddir
-      - name: meson test -v -C builddir
-        run: meson test -v -C builddir
-      - name: ./builddir/src/jdim -V
-        run: ./builddir/src/jdim -V
+          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev libltdl-dev libtool cmake zlib1g-dev ${{ matrix.sets.package }}
+      - name: cmake -S . -B build
+        run: cmake -S . -B build
+      - name: cmake --build build -j$(nproc)
+        run: cmake --build build -j$(nproc)
+      - name: ./build/test/gtest_jdim
+        run: ./build/test/gtest_jdim
+      - name: ./build/src/jdim -V
+        run: ./build/src/jdim -V
 
   compiler-22:
     runs-on: ubuntu-22.04
@@ -90,11 +65,9 @@ jobs:
           - cc: gcc-11
             cxx: g++-11
             package: g++-11
-            # Omit gcc-12 due to jobs are too many.
           - cc: clang-11
             cxx: clang++-11
             package: clang-11
-            # Omit clang-12 due to jobs are too many.
           - cc: clang-13
             cxx: clang++-13
             package: clang-13
@@ -106,15 +79,15 @@ jobs:
       - name: dependencies installation
         run: |
           sudo apt update
-          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev ${{ matrix.sets.package }}
-      - name: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
-        run: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
-      - name: ninja -C builddir
-        run: ninja -C builddir
-      - name: meson test -v -C builddir
-        run: meson test -v -C builddir
-      - name: ./builddir/src/jdim -V
-        run: ./builddir/src/jdim -V
+          sudo apt install libgnutls28-dev libgtest-dev libgtkmm-3.0-dev libltdl-dev libtool cmake zlib1g-dev ${{ matrix.sets.package }}
+      - name: cmake -S . -B build
+        run: cmake -S . -B build
+      - name: cmake --build build -j$(nproc)
+        run: cmake --build build -j$(nproc)
+      - name: ./build/test/gtest_jdim
+        run: ./build/test/gtest_jdim
+      - name: ./build/src/jdim -V
+        run: ./build/src/jdim -V
 
   autotools:
     runs-on: ${{ matrix.sets.os }}
@@ -189,26 +162,26 @@ jobs:
     strategy:
       matrix:
         deps:
-          - config_args: -Dtls=gnutls -Dsessionlib=xsmp -Dmigemo=enabled -Dalsa=enabled -Dpangolayout=enabled
+          - config_args: -Dtls=gnutls -Dsessionlib=xsmp -Dmigemo=ON -Dalsa=ON -Dpangolayout=ON
             packages: libgnutls28-dev libmigemo-dev libasound2-dev
-          - config_args: -Dtls=openssl -Dsessionlib=no -Dmigemo=enabled -Dcompat_cache_dir=disabled
+          - config_args: -Dtls=openssl -Dsessionlib=no -Dmigemo=ON -Dcompat_cache_dir=OFF
             packages: libssl-dev libmigemo-dev
-          - config_args: -Dtls=openssl -Dsessionlib=xsmp -Dalsa=enabled -Dpangolayout=enabled
+          - config_args: -Dtls=openssl -Dsessionlib=xsmp -Dalsa=ON -Dpangolayout=ON
             packages: libssl-dev libasound2-dev
     steps:
       - uses: actions/checkout@v3
       - name: dependencies installation (${{ matrix.deps.packages }})
         run: |
           sudo apt update
-          sudo apt install meson libgtest-dev libgtkmm-3.0-dev ${{ matrix.deps.packages }} g++-11
-      - name: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG" ${{ matrix.deps.config_args }}
-        run: meson builddir -Dbuildtype=debug -Dcpp_args="-D_DEBUG" ${{ matrix.deps.config_args }}
-      - name: ninja -C builddir
-        run: ninja -C builddir
-      - name: meson test -v -C builddir
-        run: meson test -v -C builddir
-      - name: ./builddir/src/jdim -V
-        run: ./builddir/src/jdim -V
+          sudo apt install cmake libgtest-dev libtool libltdl-dev libgtkmm-3.0-dev ${{ matrix.deps.packages }} g++-9
+      - name: cmake -S . -B build ${{ matrix.deps.config_args }}
+        run: cmake -S . -B build ${{ matrix.deps.config_args }}
+      - name: cmake --build build -j$(nproc)
+        run: cmake --build build -j$(nproc)
+      - name: ./build/test/gtest_jdim
+        run: ./build/test/gtest_jdim
+      - name: ./build/src/jdim -V
+        run: ./build/src/jdim -V
 
   manual-build:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,257 @@
+# JDim用 CMakeLists.txt
+# NOTE: 実験的なサポートのため変更または廃止の可能性がある
+
+# cmakeを使ってJDimをビルドする方法
+#
+# Fedora
+#   ディストロのパッケージをインストールする
+#   ```
+#   dnf install git libtool cmake
+#   dnf install gnutls-devel gtkmm30-devel libSM-devel
+#   ```
+#
+# Debian, Ubuntu
+#   ディストロのパッケージをインストールする
+#   ```
+#   sudo apt install build-essential git libtool cmake
+#   sudo apt install libgnutls28-dev libgtkmm-3.0-dev libltdl-dev
+#   ```
+#
+# ビルドの手順
+#   ```
+#   git clone -b master --depth 1 https://github.com/JDimproved/JDim.git jdim
+#   cd jdim
+#   cmake -S . -B build
+#   cmake --build build
+#   ```
+# Tips
+#   - ビルドオプションは `cmake -S . -B build -Dregex=glib` のように指定する
+#   - 生成された実行ファイルの場所は build/src/jdim
+
+cmake_minimum_required(VERSION 3.13)
+
+project(
+  jdim
+  VERSION 0.9.0
+  LANGUAGES CXX)
+# LICENSE : GPL-2.0
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# 追加コンパイルオプション
+add_compile_options(-DHAVE_CONFIG_H=1)
+add_compile_options(-DGTK_DOMAIN=\"gtk30\")
+# -Wextraで有効になる-Wunused-parameterは修正方法の検討が必要なので暫定的に無効
+add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wpedantic)
+
+# オプションの表示にはconfigureスタイル('--with-foo')が必要なので注意
+set(configure_args "")
+
+# cmake モジュール
+include(CheckCXXCompilerFlag)
+include(CheckIncludeFileCXX)
+include(CheckSymbolExists)
+include(FindPkgConfig)
+
+#
+# 必須パッケージのチェック
+#
+pkg_check_modules(GTKMM REQUIRED gtkmm-3.0>=3.24.0)
+find_package(Threads)
+pkg_check_modules(X11 REQUIRED x11)
+pkg_check_modules(ZLIB REQUIRED zlib>=1.2.0)
+
+# crypt
+find_library(CRYPT crypt)
+if(EXISTS "${CRYPT}")
+  set(CRYPT_LINK_LIBRARIES "${CRYPT}")
+else()
+  pkg_check_modules(CRYPT libcrypt)
+  if(NOT CRYPT_FOUND)
+    pkg_check_modules(CRYPT libxcrypt)
+  endif()
+endif()
+if(NOT EXISTS "${CRYPT}")
+  check_function_exists(crypt_r CRYPT)
+endif()
+if(EXISTS "${CRYPT}")
+  set(CMAKE_REQUIRED_LIBRARIES "${CRYPT}")
+  check_symbol_exists(crypt_r "crypt.h" HAVE_CRYPT_R)
+  unset(CMAKE_REQUIRED_LIBRARIES)
+endif()
+
+# socket
+find_library(SOCKET socket)
+if(EXISTS "${SOCKET}")
+  set(SOCKET_LINK_LIBRARIES "${SOCKET}")
+endif()
+
+check_symbol_exists(timegm "time.h" HAVE_TIMEGM)
+if(EXISTS "${HAVE_TIMEGM}")
+  set(NO_TIMEGM 1)
+endif()
+
+#
+# オプションのパッケージ
+#
+
+# セッション管理
+if(NOT DEFINED sessionlib)
+  set(sessionlib "xsmp")
+endif()
+if(sessionlib STREQUAL "xsmp")
+  pkg_check_modules(SM REQUIRED sm>=1.2.0)
+  pkg_check_modules(ICE REQUIRED ice>=1.0.0)
+  set(USE_XSMP 1)
+elseif(sessionlib STREQUAL "no")
+  list(APPEND configure_args "'--with-sessionlib=no'")
+else()
+  message(
+    FATAL_ERROR
+      "Value \"${sessionlib}\" for sessionlib option is not one of the choices. "
+      "Possible choices are: \"xsmp\", \"no\".")
+endif()
+
+# TLS
+if(NOT DEFINED tls)
+  set(tls "gnutls")
+endif()
+if(tls STREQUAL "gnutls")
+  pkg_check_modules(TLS REQUIRED gnutls>=3.6.7)
+  set(USE_GNUTLS 1)
+elseif(tls STREQUAL "openssl")
+  pkg_check_modules(TLS REQUIRED openssl>=1.1.1)
+  set(USE_OPENSSL 1)
+  list(APPEND configure_args "'--with-tls=openssl'")
+else()
+  message(
+    FATAL_ERROR
+      "Value \"${tls}\" for sessionlib option is not one of the choices. "
+      "Possible choices are: \"gnutls\", \"openssl\".")
+endif()
+
+# migemo
+option(migemo "Use text search by romaji" OFF)
+if(migemo)
+  find_library(MIGEMO migemo)
+  check_include_file_cxx(migemo.h HAVE_MIGEMO_H)
+  if(MIGEMO AND HAVE_MIGEMO_H)
+    set(MIGEMO_LINK_LIBRARIES "${MIGEMO}")
+  else()
+    message(FATAL_ERROR "migemo option is turned ON, but not found")
+  endif()
+endif()
+if(DEFINED migemodict)
+  set(MIGEMODICT "${migemodict}")
+  list(APPEND configure_args "'--with-migemodict=${migemodict}'")
+  message(STATUS "Default path for migemo dictionary file: ${migemodict}")
+endif()
+
+# alsa
+option(alsa "Use sound effects" OFF)
+if(alsa)
+  pkg_check_modules(ALSA REQUIRED alsa>=1.0.0)
+  set(USE_ALSA 1)
+  list(APPEND configure_args "'--with-alsa'")
+endif()
+
+# googletestが見つからない場合はテストはしない
+option(build_tests "Build test program if gtest found" ON)
+if(build_tests)
+  pkg_check_modules(GTEST_MAIN gtest_main)
+  if(NOT GTEST_MAIN_FOUND)
+    set(build_tests OFF)
+  endif()
+endif()
+
+#
+# オプションの機能
+#
+
+# Use PangoLayout instead of PangoGlyphString
+option(pangolayout "Render text by PangoLayout" OFF)
+if(pangolayout)
+  set(USE_PANGOLAYOUT 1)
+  list(APPEND configure_args "'--with-pangolayout'")
+  message(STATUS "Render text by PangoLayout: YES")
+endif()
+
+# compatible cache directory
+option(compat_cache_dir "Use compatible cache directory" ON)
+if(compat_cache_dir)
+  set(ENABLE_COMPAT_CACHE_DIR 1)
+  message(STATUS "Use compatible cache directory: YES")
+else()
+  list(APPEND configure_args "'--disable-compat-cache-dir'")
+  message(STATUS "Use compatible cache directory: NO")
+endif()
+
+#
+# コンパイラーの追加オプション
+#
+
+# gprof support
+option(gprof "Output profile information for gprof" OFF)
+if(gprof)
+  check_cxx_compiler_flag(-pg USE_GPROF)
+  if(USE_GPROF)
+    add_compile_options(-pg)
+    list(APPEND configure_args "'--enable-gprof'")
+    message(STATUS "Output profile information for gprof : YES")
+  else()
+    message(FATAL_ERROR "compiler does not support -pg option")
+  endif()
+endif()
+
+# CPUの最適化オプション
+option(native "Optimize to your machine" OFF)
+if(native)
+  check_cxx_compiler_flag(-march=native USE_NATIVE)
+  if(USE_NATIVE)
+    add_compile_options(-march=native)
+    list(APPEND configure_args "'--with-native'")
+    message(STATUS "Optimize to your machine: YES")
+  else()
+    message(FATAL_ERROR "compiler does not support -march=native option")
+  endif()
+endif()
+
+#
+# ビルドの情報
+#
+if(DEFINED packager)
+  set(PACKAGE_PACKAGER "${packager}")
+endif()
+
+message("\n*** Configuration ***")
+message("alsa = ${alsa}")
+message("build_tests = ${build_tests}")
+message("compat_cache_dir = ${compat_cache_dir}")
+message("gprof = ${gprof}")
+message("migemo = ${migemo}")
+message("migemodict = ${migemodict}")
+message("native = ${native}")
+message("packager = ${packager}")
+message("pangolayout = ${pangolayout}")
+message("regex = ${regex}")
+message("sessionlib = ${sessionlib}")
+message("tls = ${tls}")
+message("*********************\n")
+
+# ビルドオプションの文字列を空白で連結する
+string(REPLACE ";" " " CONFIGURE_ARGS "${configure_args}")
+
+add_subdirectory(src)
+if(build_tests)
+  add_subdirectory(test)
+endif()
+
+#
+# プログラムと一緒にインストールするアイコンや設定など
+#
+install(FILES jdim.png DESTINATION "share/icons/hicolor/48x48/apps")
+install(FILES jdim.svg DESTINATION "share/icons/hicolor/scalable/apps")
+
+install(FILES jdim.desktop DESTINATION "share/applications")
+install(FILES jdim.metainfo.xml DESTINATION "share/metainfo")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,139 @@
+# 作業ディレクトリの状態を反映するためにビルド毎に更新する
+add_custom_target(
+  buildinfo_h ALL
+  COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/buildinfo.h.sh
+          ${CMAKE_CURRENT_BINARY_DIR}/buildinfo.h ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Generate config.h
+string(
+  CONCAT CONFIG_H_PRE_STR
+         "#pragma once\n"
+         "#cmakedefine PACKAGE_PACKAGER \"@PACKAGE_PACKAGER@\"\n"
+         "#cmakedefine CONFIGURE_ARGS \"@CONFIGURE_ARGS@\"\n"
+         "#cmakedefine ENABLE_COMPAT_CACHE_DIR @ENABLE_COMPAT_CACHE_DIR@\n"
+         "#cmakedefine HAVE_CRYPT_R @HAVE_CRYPT_R@\n"
+         "#cmakedefine HAVE_MIGEMO_H @HAVE_MIGEMO_H@\n"
+         "#cmakedefine HAVE_ONIGPOSIX_H @HAVE_ONIGPOSIX_H@\n"
+         "#cmakedefine HAVE_REGEX_H @HAVE_REGEX_H@\n"
+         "#cmakedefine MIGEMODICT \"@MIGEMODICT@\"\n"
+         "#cmakedefine NO_TIMEGM @NO_TIMEGM@\n"
+         "#cmakedefine USE_ALSA @USE_ALSA@\n"
+         "#cmakedefine USE_GNUTLS @USE_GNUTLS@\n"
+         "#cmakedefine USE_OPENSSL @USE_OPENSSL@\n"
+         "#cmakedefine USE_PANGOLAYOUT @USE_PANGOLAYOUT@\n"
+         "#cmakedefine USE_XSMP @USE_XSMP@\n"
+         "#define HAVE_BUILDINFO_H 1\n")
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/config.h.pre "${CONFIG_H_PRE_STR}")
+configure_file(${CMAKE_CURRENT_BINARY_DIR}/config.h.pre config.h)
+
+# 実行ファイルにリンクするライブラリの構成
+set(OUT_SRC_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+set(SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+add_subdirectory(article)
+add_subdirectory(bbslist)
+add_subdirectory(board)
+add_subdirectory(config)
+add_subdirectory(control)
+add_subdirectory(dbimg)
+add_subdirectory(dbtree)
+add_subdirectory(history)
+add_subdirectory(icons)
+add_subdirectory(image)
+add_subdirectory(jdlib)
+add_subdirectory(message)
+add_subdirectory(skeleton)
+add_subdirectory(sound)
+add_subdirectory(xml)
+
+# 実行ファイルとテストプログラムに使うソースはObject libraryにする
+add_library(core_objects OBJECT)
+add_dependencies(core_objects buildinfo_h)
+
+target_include_directories(
+  core_objects PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
+                       ${GTKMM_INCLUDE_DIRS})
+
+target_sources(
+  core_objects
+  PRIVATE aamanager.cpp
+          articleitemmenupref.cpp
+          articleitempref.cpp
+          boarditemmenupref.cpp
+          boarditempref.cpp
+          browsers.cpp
+          cache.cpp
+          command.cpp
+          compmanager.cpp
+          core.cpp
+          cssmanager.cpp
+          dispatchmanager.cpp
+          dndmanager.cpp
+          environment.cpp
+          fontcolorpref.cpp
+          iomonitor.cpp
+          linkfiltermanager.cpp
+          linkfilterpref.cpp
+          livepref.cpp
+          login2ch.cpp
+          loginbe.cpp
+          mainitempref.cpp
+          maintoolbar.cpp
+          menuslots.cpp
+          msgitempref.cpp
+          openurldiag.cpp
+          prefdiagfactory.cpp
+          replacestrmanager.cpp
+          replacestrpref.cpp
+          searchitempref.cpp
+          searchloader.cpp
+          searchmanager.cpp
+          session.cpp
+          setupwizard.cpp
+          sharedbuffer.cpp
+          sidebaritempref.cpp
+          updatemanager.cpp
+          urlreplacemanager.cpp
+          usrcmdmanager.cpp
+          usrcmdpref.cpp
+          viewfactory.cpp
+          winmain.cpp)
+
+# 実行ファイルの構成
+add_executable(jdim $<TARGET_OBJECTS:core_objects>)
+install(TARGETS jdim DESTINATION bin)
+
+target_include_directories(
+  jdim PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
+               ${GTKMM_INCLUDE_DIRS} ${ICE_INCLUDE_DIRS} ${SM_INCLUDE_DIRS})
+
+target_link_libraries(
+  jdim
+  PRIVATE article
+          bbslist
+          board
+          config
+          control
+          dbimg
+          dbtree
+          history
+          icon
+          image
+          message # raise link error if put message behind jdlib
+          jdlib
+          skeleton
+          sound
+          xml
+          ${ALSA_LINK_LIBRARIES}
+          ${CMAKE_THREAD_LIBS_INIT}
+          ${CRYPT_LINK_LIBRARIES}
+          ${GTKMM_LINK_LIBRARIES}
+          ${ICE_LINK_LIBRARIES}
+          ${MIGEMO_LINK_LIBRARIES}
+          ${REGEXP_LINK_LIBRARIES}
+          ${SM_LINK_LIBRARIES}
+          ${SOCKET_LINK_LIBRARIES}
+          ${TLS_LINK_LIBRARIES}
+          ${X11_LINK_LIBRARIES}
+          ${ZLIB_LINK_LIBRARIES})
+
+target_sources(jdim PRIVATE main.cpp)

--- a/src/article/CMakeLists.txt
+++ b/src/article/CMakeLists.txt
@@ -1,0 +1,26 @@
+add_library(article STATIC)
+
+target_include_directories(article PRIVATE ${OUT_SRC_DIR} ${SRC_DIR}
+                                           ${GTKMM_INCLUDE_DIRS})
+
+target_sources(
+  article
+  PRIVATE articleadmin.cpp
+          articleview.cpp
+          articleviewbase.cpp
+          articleviewetc.cpp
+          articleviewinfo.cpp
+          articleviewpopup.cpp
+          articleviewpreview.cpp
+          articleviewsearch.cpp
+          drawareabase.cpp
+          drawareainfo.cpp
+          drawareamain.cpp
+          drawareapopup.cpp
+          embeddedimage.cpp
+          font.cpp
+          layouttree.cpp
+          preference.cpp
+          toolbar.cpp
+          toolbarsearch.cpp
+          toolbarsimple.cpp)

--- a/src/bbslist/CMakeLists.txt
+++ b/src/bbslist/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_library(bbslist STATIC)
+
+target_include_directories(bbslist PRIVATE ${OUT_SRC_DIR} ${SRC_DIR}
+                                           ${GTKMM_INCLUDE_DIRS})
+
+target_sources(
+  bbslist
+  PRIVATE addetcdialog.cpp
+          bbslistadmin.cpp
+          bbslistview.cpp
+          bbslistviewbase.cpp
+          columns.cpp
+          editlistwin.cpp
+          favoriteview.cpp
+          historyview.cpp
+          selectdialog.cpp
+          selectlistview.cpp
+          toolbar.cpp)

--- a/src/board/CMakeLists.txt
+++ b/src/board/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(board STATIC)
+
+target_include_directories(board PRIVATE ${OUT_SRC_DIR} ${SRC_DIR}
+                                         ${GTKMM_INCLUDE_DIRS})
+
+target_sources(
+  board
+  PRIVATE boardadmin.cpp
+          boardview.cpp
+          boardviewbase.cpp
+          boardviewlog.cpp
+          boardviewnext.cpp
+          boardviewsidebar.cpp
+          preference.cpp
+          toolbar.cpp)

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(config STATIC)
+
+target_include_directories(config PRIVATE ${OUT_SRC_DIR} ${SRC_DIR}
+                                          ${GTKMM_INCLUDE_DIRS})
+
+target_sources(config PRIVATE aboutconfig.cpp aboutconfigdiag.cpp
+                              configitems.cpp globalconf.cpp)

--- a/src/control/CMakeLists.txt
+++ b/src/control/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_library(control STATIC)
+
+target_include_directories(control PRIVATE ${OUT_SRC_DIR} ${SRC_DIR}
+                                           ${GTKMM_INCLUDE_DIRS})
+
+target_sources(
+  control
+  PRIVATE buttonconfig.cpp
+          buttonpref.cpp
+          control.cpp
+          controlutil.cpp
+          keyconfig.cpp
+          keypref.cpp
+          mouseconfig.cpp
+          mousekeyconf.cpp
+          mousekeypref.cpp
+          mousepref.cpp)

--- a/src/dbimg/CMakeLists.txt
+++ b/src/dbimg/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(dbimg STATIC)
+
+target_include_directories(dbimg PRIVATE ${OUT_SRC_DIR} ${SRC_DIR}
+                                         ${GTKMM_INCLUDE_DIRS})
+
+target_sources(dbimg PRIVATE delimgcachediag.cpp img.cpp imginterface.cpp
+                             imgroot.cpp)

--- a/src/dbtree/CMakeLists.txt
+++ b/src/dbtree/CMakeLists.txt
@@ -1,0 +1,34 @@
+add_library(dbtree STATIC)
+
+target_include_directories(dbtree PRIVATE ${OUT_SRC_DIR} ${SRC_DIR}
+                                          ${GTKMM_INCLUDE_DIRS})
+
+target_sources(
+  dbtree
+  PRIVATE article2ch.cpp
+          article2chcompati.cpp
+          articlebase.cpp
+          articlehash.cpp
+          articlejbbs.cpp
+          articlelocal.cpp
+          articlemachi.cpp
+          board2ch.cpp
+          board2chcompati.cpp
+          boardbase.cpp
+          boardfactory.cpp
+          boardjbbs.cpp
+          boardlocal.cpp
+          boardmachi.cpp
+          frontloader.cpp
+          interface.cpp
+          nodetree2ch.cpp
+          nodetree2chcompati.cpp
+          nodetreebase.cpp
+          nodetreedummy.cpp
+          nodetreejbbs.cpp
+          nodetreelocal.cpp
+          nodetreemachi.cpp
+          root.cpp
+          ruleloader.cpp
+          settingloader.cpp
+          spchar_decoder.cpp)

--- a/src/history/CMakeLists.txt
+++ b/src/history/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(history STATIC)
+
+target_include_directories(history PRIVATE ${OUT_SRC_DIR} ${SRC_DIR}
+                                           ${GTKMM_INCLUDE_DIRS})
+
+target_sources(history PRIVATE historymanager.cpp historymenu.cpp
+                               historysubmenu.cpp viewhistory.cpp)

--- a/src/icons/CMakeLists.txt
+++ b/src/icons/CMakeLists.txt
@@ -1,0 +1,58 @@
+set(icon_files
+    bkmark.png
+    bkmark_broken_subject.png
+    bkmark_thread.png
+    bkmark_update.png
+    board.png
+    board_update.png
+    board_updated.png
+    broken_subject.png
+    check.png
+    dir.png
+    down.png
+    favorite.png
+    hist.png
+    hist_board.png
+    hist_close.png
+    hist_closeboard.png
+    hist_closeimg.png
+    image.png
+    info.png
+    jd16.png
+    jd32.png
+    jd48.png
+    jd96.png
+    link.png
+    loading.png
+    loading_stop.png
+    newthread.png
+    newthread_hour.png
+    post.png
+    post_refer.png
+    thread.png
+    thread_old.png
+    thread_update.png
+    thread_updated.png
+    update.png
+    write.png)
+
+find_program(gdk_pixbuf_csource gdk-pixbuf-csource)
+
+# Generate CXX header files from icon png images.
+foreach(f IN ITEMS ${icon_files})
+  # Get filename without extension.
+  string(REGEX REPLACE "^(.*)\\.[^.]*$" "\\1" basename "${f}")
+  add_custom_command(
+    OUTPUT "${basename}.h"
+    COMMAND ${gdk_pixbuf_csource} --raw --name="icon_${basename}"
+            "${CMAKE_CURRENT_SOURCE_DIR}/${f}" >"${basename}.h")
+  list(APPEND icon_headers "${basename}.h")
+endforeach()
+
+add_library(icon STATIC)
+
+target_include_directories(
+  icon PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${OUT_SRC_DIR} ${SRC_DIR}
+               ${GTKMM_INCLUDE_DIRS})
+
+target_sources(icon PRIVATE iconmanager.cpp ${icon_headers})

--- a/src/image/CMakeLists.txt
+++ b/src/image/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_library(image STATIC)
+
+target_include_directories(image PRIVATE ${OUT_SRC_DIR} ${SRC_DIR}
+                                         ${GTKMM_INCLUDE_DIRS})
+
+target_sources(
+  image
+  PRIVATE imageadmin.cpp
+          imagearea.cpp
+          imageareabase.cpp
+          imageareaicon.cpp
+          imageareapopup.cpp
+          imageview.cpp
+          imageviewbase.cpp
+          imageviewicon.cpp
+          imageviewpopup.cpp
+          imagewin.cpp
+          preference.cpp)

--- a/src/jdlib/CMakeLists.txt
+++ b/src/jdlib/CMakeLists.txt
@@ -1,0 +1,33 @@
+add_library(jdlib STATIC)
+
+target_include_directories(
+  jdlib
+  PRIVATE ${OUT_SRC_DIR}
+          ${SRC_DIR}
+          ${GTKMM_INCLUDE_DIRS}
+          ${REGEXP_INCLUDE_DIRS}
+          ${TLS_INCLUDE_DIRS}
+          ${X11_INCLUDE_DIRS}
+          ${ZLIB_INCLUDE_DIRS})
+
+target_sources(
+  jdlib
+  PRIVATE confloader.cpp
+          cookiemanager.cpp
+          heap.cpp
+          imgloader.cpp
+          jdiconv.cpp
+          jdmigemo.cpp
+          jdregex.cpp
+          loader.cpp
+          loaderdata.cpp
+          misccharcode.cpp
+          miscgtk.cpp
+          miscmsg.cpp
+          misctime.cpp
+          misctrip.cpp
+          miscutil.cpp
+          miscx.cpp
+          ssl.cpp
+          tfidf.cpp
+          timeout.cpp)

--- a/src/message/CMakeLists.txt
+++ b/src/message/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(message STATIC)
+
+target_include_directories(message PRIVATE ${OUT_SRC_DIR} ${SRC_DIR}
+                                           ${GTKMM_INCLUDE_DIRS})
+
+target_sources(
+  message
+  PRIVATE confirmdiag.cpp
+          logmanager.cpp
+          messageadmin.cpp
+          messageview.cpp
+          messageviewbase.cpp
+          messagewin.cpp
+          post.cpp
+          toolbar.cpp)

--- a/src/skeleton/CMakeLists.txt
+++ b/src/skeleton/CMakeLists.txt
@@ -1,0 +1,48 @@
+add_library(skeleton STATIC)
+
+target_include_directories(skeleton PRIVATE ${OUT_SRC_DIR} ${SRC_DIR}
+                                            ${GTKMM_INCLUDE_DIRS})
+
+target_sources(
+  skeleton
+  PRIVATE aamenu.cpp
+          aboutdiag.cpp
+          admin.cpp
+          backforwardbutton.cpp
+          compentry.cpp
+          detaildiag.cpp
+          dispatchable.cpp
+          dragnote.cpp
+          dragtreeview.cpp
+          editcolumns.cpp
+          edittreeview.cpp
+          editview.cpp
+          entry.cpp
+          hpaned.cpp
+          jdtoolbar.cpp
+          label_entry.cpp
+          loadable.cpp
+          login.cpp
+          menubutton.cpp
+          msgdiag.cpp
+          notebook.cpp
+          panecontrol.cpp
+          popupwin.cpp
+          popupwinbase.cpp
+          prefdiag.cpp
+          selectitempref.cpp
+          tablabel.cpp
+          tabnote.cpp
+          tabswitchbutton.cpp
+          tabswitchmenu.cpp
+          textloader.cpp
+          toolbar.cpp
+          toolbarnote.cpp
+          toolmenubutton.cpp
+          treeviewbase.cpp
+          undobuffer.cpp
+          vbox.cpp
+          view.cpp
+          viewnote.cpp
+          vpaned.cpp
+          window.cpp)

--- a/src/sound/CMakeLists.txt
+++ b/src/sound/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(sound STATIC)
+
+target_include_directories(
+  sound PRIVATE ${OUT_SRC_DIR} ${SRC_DIR} ${ALSA_INCLUDE_DIRS}
+                ${GTKMM_INCLUDE_DIRS})
+
+target_sources(sound PRIVATE playsound.cpp soundmanager.cpp)

--- a/src/xml/CMakeLists.txt
+++ b/src/xml/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(xml STATIC)
+
+target_include_directories(xml PRIVATE ${OUT_SRC_DIR} ${SRC_DIR}
+                                       ${GTKMM_INCLUDE_DIRS})
+
+target_sources(xml PRIVATE document.cpp dom.cpp tools.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,27 @@
+include(GoogleTest)
+enable_testing()
+
+add_executable(gtest_jdim $<TARGET_OBJECTS:core_objects>)
+gtest_discover_tests(gtest_jdim)
+
+target_include_directories(
+  gtest_jdim PRIVATE $<TARGET_PROPERTY:jdim,INCLUDE_DIRECTORIES>
+                     ${GTEST_MAIN_INCLUDE_DIRS})
+
+target_link_libraries(gtest_jdim PRIVATE $<TARGET_PROPERTY:jdim,LINK_LIBRARIES>
+                                         ${GTEST_MAIN_LINK_LIBRARIES})
+
+target_sources(
+  gtest_jdim
+  PRIVATE gtest_dbtree_nodetreebase.cpp
+          gtest_dbtree_spchar_decoder.cpp
+          gtest_jdlib_cookiemanager.cpp
+          gtest_jdlib_jdiconv.cpp
+          gtest_jdlib_jdregex.cpp
+          gtest_jdlib_loader.cpp
+          gtest_jdlib_misccharcode.cpp
+          gtest_jdlib_misctime.cpp
+          gtest_jdlib_misctrip.cpp
+          gtest_jdlib_miscutil.cpp
+          gtest_jdlib_span.cpp
+          gtest_xml_dom.cpp)


### PR DESCRIPTION
**このPRはアイデア検証用でありマージしません。**

- **[IDEA] Add CMakeLists.txt for experimental support 2022-12**  
  C++製のビルドツール[CMake][1]をサポートするため構成ファイル(CMakeLists.txt)を追加します。
  導入方法やビルドの手順はリポジトリのルートディレクトリに置かれたCMakeLists.txtの冒頭に要点を載せています。
  詳細はCMakeのwebサイトを参照してください。

  注意
  実験的なサポートのため変更または廃止の可能性があります。
  Formatted by cmake-format 0.6.13 using default options.

[1]: https://cmake.org/cmake/help/v3.13/

- **[IDEA] Add GitHub Action CI jobs for CMake**  
  CMakeでビルド＆テストするjobをGitHub Actionsワークフローに追加します。

以前のテスト: ma8ma#56, ma8ma#61
