### PR TITLE
[DO NOT MERGE] Add handling to use 2ch proxy if past logs not available without proxy

### DIFF
--- a/src/config/configitems.cpp
+++ b/src/config/configitems.cpp
@@ -110,6 +110,7 @@ bool ConfigItems::load( const bool restore )
     str_tmp = cf.get_option_str( "proxy_for2ch", "" );
     set_proxy_for2ch( str_tmp );
     proxy_port_for2ch = cf.get_option_int( "proxy_port_for2ch", CONF_PROXY_PORT_FOR2CH, 1, 65535 );
+    use_fallback_proxy_for2ch = cf.get_option_bool( "use_fallback_proxy_for2ch", CONF_USE_FALLBACK_PROXY_FOR2CH );
 
     // 書き込み用プロクシとポート番号
     use_proxy_for2ch_w = cf.get_option_bool( "use_proxy_for2ch_w", CONF_USE_PROXY_FOR2CH_W );
@@ -700,6 +701,7 @@ void ConfigItems::save_impl( const std::string& path )
     cf.update( "send_cookie_to_proxy_for2ch", send_cookie_to_proxy_for2ch );
     cf.update( "proxy_for2ch", tmp_proxy );
     cf.update( "proxy_port_for2ch", proxy_port_for2ch );
+    cf.update( "use_fallback_proxy_for2ch", use_fallback_proxy_for2ch );
 
     if( proxy_basicauth_for2ch_w.empty() ) tmp_proxy = proxy_for2ch_w;
     else tmp_proxy = proxy_basicauth_for2ch_w + "@" + proxy_for2ch_w;

--- a/src/config/configitems.h
+++ b/src/config/configitems.h
@@ -53,6 +53,7 @@ namespace CONFIG
         std::string proxy_for2ch;
         int proxy_port_for2ch{};
         std::string proxy_basicauth_for2ch;
+        bool use_fallback_proxy_for2ch{};
 
         // 書き込み用プロクシとポート番号
         bool use_proxy_for2ch_w{};

--- a/src/config/defaultconf.h
+++ b/src/config/defaultconf.h
@@ -21,6 +21,7 @@ namespace CONFIG
         CONF_USE_PROXY_FOR2CH = 0, // 2ch 読み込み用プロクシを使用するか
         CONF_SEND_COOKIE_TO_PROXY_FOR2CH = 0, // 2ch 読み込み用プロクシにクッキーを送信するか
         CONF_PROXY_PORT_FOR2CH = 8080, // 2ch 読み込み用プロクシポート番号
+        CONF_USE_FALLBACK_PROXY_FOR2CH = 0, ///< プロキシを使わない接続で過去ログが見つからなかったときは2ch読み込み用プロキシを使う
         CONF_USE_PROXY_FOR2CH_W = 0, // 2ch 書き込み用プロクシを使用するか
         CONF_SEND_COOKIE_TO_PROXY_FOR2CH_W = 0, // 2ch 書き込み用プロクシにクッキーを送信するか
         CONF_PROXY_PORT_FOR2CH_W = 8080, // 2ch 書き込み用プロクシポート番号

--- a/src/config/globalconf.cpp
+++ b/src/config/globalconf.cpp
@@ -189,11 +189,13 @@ bool CONFIG::get_send_cookie_to_proxy_for2ch() { return get_confitem()->send_coo
 const std::string& CONFIG::get_proxy_for2ch() { return get_confitem()->proxy_for2ch; }
 int CONFIG::get_proxy_port_for2ch() { return get_confitem()->proxy_port_for2ch; }
 const std::string& CONFIG::get_proxy_basicauth_for2ch() { return get_confitem()->proxy_basicauth_for2ch; }
+bool CONFIG::get_use_fallback_proxy_for2ch() { return get_confitem()->use_fallback_proxy_for2ch; }
 
 void CONFIG::set_use_proxy_for2ch( bool set ){ get_confitem()->use_proxy_for2ch = set; }
 void CONFIG::set_send_cookie_to_proxy_for2ch( bool set ){ get_confitem()->send_cookie_to_proxy_for2ch = set; }
 void CONFIG::set_proxy_for2ch( const std::string& proxy ){ get_confitem()->set_proxy_for2ch( proxy ); }
 void CONFIG::set_proxy_port_for2ch( int port ){ get_confitem()->proxy_port_for2ch = port; }
+void CONFIG::set_use_fallback_proxy_for2ch( bool set ) { get_confitem()->use_fallback_proxy_for2ch = set; }
 
 bool CONFIG::get_use_proxy_for2ch_w() { return get_confitem()->use_proxy_for2ch_w; }
 bool CONFIG::get_send_cookie_to_proxy_for2ch_w() { return get_confitem()->send_cookie_to_proxy_for2ch_w; }

--- a/src/config/globalconf.h
+++ b/src/config/globalconf.h
@@ -152,11 +152,14 @@ namespace CONFIG
     const std::string& get_proxy_for2ch();
     int get_proxy_port_for2ch();
     const std::string& get_proxy_basicauth_for2ch();
+    bool get_use_fallback_proxy_for2ch();
 
     void set_use_proxy_for2ch( const bool set );
     void set_send_cookie_to_proxy_for2ch( bool set );
     void set_proxy_for2ch( const std::string& proxy );
     void set_proxy_port_for2ch( const int port );
+    void set_use_fallback_proxy_for2ch( const bool set );
+
 
     // 2ch 書き込み用プロクシとポート番号
     bool get_use_proxy_for2ch_w();

--- a/src/dbtree/nodetree2ch.cpp
+++ b/src/dbtree/nodetree2ch.cpp
@@ -27,6 +27,7 @@ enum
 {
     MODE_NORMAL = 0,
     MODE_KAKO,
+    MODE_KAKO_PROXY,
     MODE_OLDURL
 };
 
@@ -176,9 +177,16 @@ void NodeTree2ch::create_loaderdata( JDLIB::LOADERDATA& data )
     std::cout << "agent = " << data.agent << std::endl;
 #endif
 
-    data.host_proxy = DBTREE::get_proxy_host( get_url() );
-    data.port_proxy = DBTREE::get_proxy_port( get_url() );
-    data.basicauth_proxy = DBTREE::get_proxy_basicauth( get_url() );
+    if( m_mode == MODE_KAKO_PROXY ) {
+        data.host_proxy = CONFIG::get_proxy_for2ch();
+        data.port_proxy = CONFIG::get_proxy_port_for2ch();
+        data.basicauth_proxy = CONFIG::get_proxy_basicauth_for2ch();
+    }
+    else {
+        data.host_proxy = DBTREE::get_proxy_host( get_url() );
+        data.port_proxy = DBTREE::get_proxy_port( get_url() );
+        data.basicauth_proxy = DBTREE::get_proxy_basicauth( get_url() );
+    }
     data.cookie_for_request = DBTREE::board_cookie_for_request( get_url() );
 
     data.size_buf = CONFIG::get_loader_bufsize();
@@ -214,6 +222,9 @@ void NodeTree2ch::receive_finish()
         (1) https://HOGE.5ch.net/hoge/dat/1234567890.dat から DAT を取得。
         (2) https://HOGE.5ch.net/hoge/oyster/1234/1234567890.dat から取得。
         (3) 旧URL(過去ログサーバ)がある場合、そのURLで再取得
+        取得できなかったとき -> 最初にプロキシを使わない接続で読み込めるか試す設定なら(4)へ
+
+        (4) プロキシに接続して取得
 
         ・スレIDが9桁の場合 -> https://サーバ/板ID/oyster/IDの上位3桁/ID.dat
 
@@ -221,6 +232,9 @@ void NodeTree2ch::receive_finish()
         (1) https://HOGE.5ch.net/hoge/dat/123456789.dat から DAT を取得。
         (2) https://HOGE.5ch.net/hoge/oyster/123/123456789.dat から取得。
         (3) 旧URL(過去ログサーバ)がある場合、そのURLで再取得
+        取得できなかったとき -> 最初にプロキシを使わない接続で読み込めるか試す設定なら(4)へ
+
+        (4) プロキシに接続して取得
 */
 
         // DAT落ちした現役サーバに収容されているスレッド
@@ -228,6 +242,11 @@ void NodeTree2ch::receive_finish()
 
         // 旧URL(過去ログサーバ)に収容されているスレッド
         else if( m_mode == MODE_KAKO && get_url() != m_org_url ) m_mode = MODE_OLDURL;
+
+        // プロキシを使わない接続で過去ログが見つからなかったときは2ch読み込み用プロキシを使うモード
+        else if( ( m_mode == MODE_KAKO || m_mode == MODE_OLDURL )
+                 && CONFIG::get_use_fallback_proxy_for2ch()
+                 && ! CONFIG::get_proxy_for2ch().empty() ) m_mode = MODE_KAKO_PROXY;
 
         // 失敗
         else m_mode = MODE_NORMAL;

--- a/src/proxypref.h
+++ b/src/proxypref.h
@@ -16,6 +16,11 @@ namespace CORE
 {
     constexpr const char kSendCookieTooltip[] = "JDimからプロキシへサイトのクッキーを送信します。\n"
                                                 "プロキシのクッキー処理にあわせて設定してください。";
+    constexpr const char* kFallbackProxyNotice =
+        "スレッドの途中からプロキシ接続に代わるとdatファイルの整合性が取れなくなり"
+        "\"416 Requested Range Not Satisfiable\"の通信エラーが出ることがあります。"
+        "その場合はスレ情報を消さずに再取得を行ってください。"
+        "このオプションは実験的なサポートのため変更または廃止の可能性があります。";
 
     class ProxyFrame : public Gtk::Frame
     {
@@ -54,12 +59,86 @@ namespace CORE
         }
     };
 
+    class ProxyFrameFallbackOption : public Gtk::Frame
+    {
+        Gtk::Box m_vbox;
+        Gtk::Box m_hbox;
+
+        Gtk::Box m_vbox_exp_option;
+        Gtk::Box m_hbox_fallback_proxy;
+        Glib::RefPtr<Glib::Binding> m_binding_notice;
+        Gtk::ToggleButton m_toggle_notice;
+        Gtk::Revealer m_revealer_notice;
+
+      public:
+
+        Gtk::CheckButton ckbt;
+        Gtk::CheckButton send_cookie_check;
+
+        Gtk::CheckButton fallback_proxy_check;
+        Gtk::Label notice_label;
+
+        SKELETON::LabelEntry entry_host;
+        SKELETON::LabelEntry entry_port;
+
+        ProxyFrameFallbackOption( const std::string& title, const Glib::ustring& ckbt_label,
+                                       const Glib::ustring& send_label, const Glib::ustring& fallback_label,
+                                       const Glib::ustring& host_label, const Glib::ustring& port_label )
+            : m_vbox( Gtk::ORIENTATION_VERTICAL, 0 )
+            , m_hbox( Gtk::ORIENTATION_HORIZONTAL, 8 )
+            , m_vbox_exp_option( Gtk::ORIENTATION_VERTICAL, 0 )
+            , m_hbox_fallback_proxy( Gtk::ORIENTATION_HORIZONTAL, 0 )
+            , m_toggle_notice( "注意事項" )
+            , ckbt( ckbt_label, true )
+            , send_cookie_check( send_label, true )
+            , fallback_proxy_check( fallback_label, true )
+            , notice_label( kFallbackProxyNotice, false )
+            , entry_host( true, host_label)
+            , entry_port( true, port_label )
+        {
+            send_cookie_check.set_tooltip_text( kSendCookieTooltip );
+
+            fallback_proxy_check.set_halign( Gtk::ALIGN_START );
+            m_toggle_notice.set_halign( Gtk::ALIGN_END );
+
+            m_revealer_notice.add( notice_label );
+            m_revealer_notice.set_reveal_child( false );
+            notice_label.set_line_wrap( true );
+            notice_label.set_margin_end( 8 );
+            notice_label.set_margin_start( 8 );
+
+            m_binding_notice = Glib::Binding::bind_property( m_toggle_notice.property_active(),
+                                                             m_revealer_notice.property_reveal_child() );
+
+            m_hbox.pack_start( ckbt, Gtk::PACK_SHRINK );
+            m_hbox.pack_start( send_cookie_check, Gtk::PACK_SHRINK );
+            m_hbox.pack_start( entry_host );
+            m_hbox.pack_start( entry_port, Gtk::PACK_SHRINK );
+
+            m_hbox_fallback_proxy.set_hexpand( true );
+            m_hbox_fallback_proxy.set_margin_start( 8 );
+            m_hbox_fallback_proxy.set_margin_end( 8 );
+            m_hbox_fallback_proxy.pack_start( fallback_proxy_check, Gtk::PACK_SHRINK );
+            m_hbox_fallback_proxy.pack_end( m_toggle_notice, Gtk::PACK_SHRINK );
+            m_vbox_exp_option.pack_start( m_hbox_fallback_proxy, Gtk::PACK_SHRINK );
+            m_vbox_exp_option.pack_start( m_revealer_notice, Gtk::PACK_SHRINK );
+
+            m_hbox.set_border_width( 8 );
+            m_vbox.pack_start( m_hbox, Gtk::PACK_SHRINK );
+            m_vbox.pack_start( m_vbox_exp_option, Gtk::PACK_SHRINK );
+
+            set_label( title );
+            set_border_width( 8 );
+            add( m_vbox );
+        }
+    };
+
     class ProxyPref : public SKELETON::PrefDiag
     {
         Gtk::Label m_label;
 
         // 2ch読み込み用
-        ProxyFrame m_frame_2ch;
+        ProxyFrameFallbackOption m_frame_2ch;
 
         // 2ch書き込み用
         ProxyFrame m_frame_2ch_w;
@@ -75,6 +154,7 @@ namespace CORE
             CONFIG::set_send_cookie_to_proxy_for2ch( m_frame_2ch.send_cookie_check.get_active() );
             CONFIG::set_proxy_for2ch( MISC::utf8_trim( m_frame_2ch.entry_host.get_text().raw() ) );
             CONFIG::set_proxy_port_for2ch( atoi( m_frame_2ch.entry_port.get_text().c_str() ) );
+            CONFIG::set_use_fallback_proxy_for2ch( m_frame_2ch.fallback_proxy_check.get_active() );
 
             // 2ch書き込み用
             CONFIG::set_use_proxy_for2ch_w( m_frame_2ch_w.ckbt.get_active() );
@@ -94,8 +174,10 @@ namespace CORE
         ProxyPref( Gtk::Window* parent, const std::string& url )
             : SKELETON::PrefDiag( parent, url )
             , m_label( "認証を行う場合はホスト名を「ユーザID:パスワード@ホスト名」としてください。" )
-            , m_frame_2ch( "2ch読み込み用", "使用する(_U)", "クッキーを送る(_I)",
-                           "ホスト名(_H)： ", "ポート番号(_P)： " )
+            , m_frame_2ch(
+                "2ch読み込み用", "使用する(_U)", "クッキーを送る(_I)",
+                "プロキシを使わない接続で過去ログが見つからなかったときは2ch読み込み用プロキシを使う(_D)",
+                "ホスト名(_H)： ", "ポート番号(_P)： " )
             , m_frame_2ch_w( "2ch書き込み用", "使用する(_S)", "クッキーを送る(_J)",
                              "ホスト名(_N)： ", "ポート番号(_R)： " )
             , m_frame_data( "その他のサーバ用(板一覧、外部板、画像など)", "使用する(_E)", "クッキーを送る(_K)",
@@ -110,6 +192,7 @@ namespace CORE
             else host = CONFIG::get_proxy_basicauth_for2ch() + "@" + CONFIG::get_proxy_for2ch();
             m_frame_2ch.entry_host.set_text( host );
             m_frame_2ch.entry_port.set_text( std::to_string( CONFIG::get_proxy_port_for2ch() ) );
+            m_frame_2ch.fallback_proxy_check.set_active( CONFIG::get_use_fallback_proxy_for2ch() );
 
             set_activate_entry( m_frame_2ch.entry_host );
             set_activate_entry( m_frame_2ch.entry_port );
@@ -143,6 +226,9 @@ namespace CORE
             get_content_area()->pack_start( m_frame_data );
 
             set_title( "プロキシ設定" );
+            // 2ch読み込み用設定にある label のテキストを wrap するためダイアログのサイズを設定しておく
+            // 実際はウィジェットの最小サイズを考慮した大きさになる
+            set_default_size( 100, 100 );
             show_all_children();
         }
 


### PR DESCRIPTION
**このPRはマージしません。**

JDimproved/JDim#1202 を修正するパッチです。
この修正がなくても過去ログが読み込めるようになったためmasterブランチにはマージせず放棄します。