### PR TITLE
[DO NOT MERGE] NodeTreeBase: Parse HTML img tag

### DIFF
--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -341,6 +341,9 @@ namespace DBTREE
         void parse_html( const char* str, std::size_t lng_str, const int color_text,
                          bool digitlink, const bool bold, const char fontid = FONT_MAIN );
 
+        bool parse_a( const char*& pos, const char* pos_end, int bgcolor, bool bold, char fontid );
+        bool parse_img( const char*& pos, const char* pos_end, bool bold, char fontid );
+
         // 書き込みログ比較用文字列作成
         // m_buffer_write に作成した文字列をセットする
         void parse_write( std::string_view str, const std::size_t max_lng_write );


### PR DESCRIPTION
**このPRはマージしません。**

`<img>`タグを解析してHTMLの画像埋め込み要素から画像URLを抽出して表示します。

### 放棄の理由
2023-07-11 から5ch.netのDATファイルへのアクセスが開放されました。
5chのDATはsssp:でリンクが貼られているため`<img>`タグを解析する必要がありません。

また、プロキシには`<img>`タグをURLに変換するオプションが利用できるものもあります。