### PR TITLE
[DO NOT MERGE] Add NGID by abone word and regex

### DIFF
--- a/src/article/preference.h
+++ b/src/article/preference.h
@@ -32,13 +32,14 @@ namespace ARTICLE
         Gtk::ComboBoxText m_combo_charset;
 
         // あぼーん
-        Gtk::VBox m_vbox_abone;
+        Gtk::Grid m_grid_abone;
         Gtk::Notebook m_notebook_abone;
         Gtk::VBox m_vbox_abone_id;
         Gtk::Label m_label_abone_id;
         SKELETON::EditView m_edit_id, m_edit_res, m_edit_name, m_edit_word, m_edit_regex;
 
         Gtk::Label m_label_abone;
+        Gtk::Label m_label_abone_add_abone_id;
 
         // 透明あぼーん
         Gtk::CheckButton m_check_transpabone;
@@ -60,6 +61,12 @@ namespace ARTICLE
 
         // 全体レベルでのあぼーん
         Gtk::CheckButton m_check_globalabone;
+
+        /// ワードであぼーんした投稿者をNG IDに追加する
+        Gtk::CheckButton m_check_abone_word_add_abone_id;
+
+        /// 正規表現であぼーんした投稿者をNG IDに追加する
+        Gtk::CheckButton m_check_abone_regex_add_abone_id;
 
         Gtk::Box m_hbox_since;
         SKELETON::LabelEntry m_label_since;

--- a/src/dbtree/articlebase.h
+++ b/src/dbtree/articlebase.h
@@ -87,6 +87,8 @@ namespace DBTREE
         bool m_abone_noid{}; // ID無しをあぼーん
         bool m_abone_board; // 板レベルでのあぼーんを有効にする
         bool m_abone_global; // 全体レベルでのあぼーんを有効にする
+        bool m_abone_word_add_abone_id{}; ///< ワードであぼーんした投稿者をNG IDに追加する
+        bool m_abone_regex_add_abone_id{}; ///< 正規表現であぼーんした投稿者をNG IDに追加する
 
         // 「スレ」がスレ一覧でブックマークされているか
         bool m_bookmarked_thread{};
@@ -355,6 +357,12 @@ namespace DBTREE
         // 全体レベルでのあぼーん
         bool get_abone_global() const { return m_abone_global; }
 
+        /// ワードであぼーんした投稿者をNG IDに追加する
+        bool get_abone_word_add_abone_id() const noexcept { return m_abone_word_add_abone_id; }
+
+        /// 正規表現であぼーんした投稿者をNG IDに追加する
+        bool get_abone_regex_add_abone_id() const noexcept { return m_abone_regex_add_abone_id; }
+
         // number番のレスがあぼーんされているか
         bool get_abone( int number );
 
@@ -369,7 +377,8 @@ namespace DBTREE
                           const std::vector< char >& vec_abone_res,
                           const bool transparent, const bool chain, const bool age,
                           const bool default_name, const bool noid,
-                          const bool board, const bool global
+                          const bool board, const bool global,
+                          const bool abone_word_add_abone_id, const bool abone_regex_add_abone_id
             );
 
         // あぼ〜ん状態更新(reset_abone()と違って各項目ごと個別におこなう)
@@ -384,6 +393,8 @@ namespace DBTREE
         void set_abone_noid( const bool set ); // ID無し
         void set_abone_board( const bool set ); // 板レベルでのあぼーん
         void set_abone_global( const bool set ); // 全体レベルでのあぼーん
+        void set_abone_word_add_abone_id( const bool set ); // ワードであぼーんした投稿者をNG IDに追加する
+        void set_abone_regex_add_abone_id( const bool set ); // 正規表現であぼーんした投稿者をNG IDに追加する
 
 
         // 「スレ」のブックマーク

--- a/src/dbtree/interface.cpp
+++ b/src/dbtree/interface.cpp
@@ -1287,11 +1287,13 @@ void DBTREE::reset_abone( const std::string& url,
                           const std::vector< char >& vec_abone_res,
                           const bool transparent, const bool chain, const bool age,
                           const bool default_name, const bool noid,
-                          const bool board, const bool global
+                          const bool board, const bool global,
+                          const bool abone_word_add_abone_id, const bool abone_regex_add_abone_id
     )
 {
     DBTREE::get_article( url )->reset_abone( ids, names, words, regexs, vec_abone_res, transparent, chain, age,
-                                             default_name, noid, board, global );
+                                             default_name, noid, board, global,
+                                             abone_word_add_abone_id, abone_regex_add_abone_id );
 }
 
 
@@ -1406,6 +1408,32 @@ bool DBTREE::get_abone_global( const std::string& url )
 void DBTREE::set_abone_global( const std::string& url, const bool set )
 {
     DBTREE::get_article( url )->set_abone_global( set );
+}
+
+
+// ワードであぼーんした投稿者をNG IDに追加する
+bool DBTREE::get_abone_word_add_abone_id( const std::string& url )
+{
+    return DBTREE::get_article( url )->get_abone_word_add_abone_id();
+}
+
+
+void DBTREE::set_abone_word_add_abone_id( const std::string& url, const bool set )
+{
+    DBTREE::get_article( url )->set_abone_word_add_abone_id( set );
+}
+
+
+// 正規表現であぼーんした投稿者をNG IDに追加する
+bool DBTREE::get_abone_regex_add_abone_id( const std::string& url )
+{
+    return DBTREE::get_article( url )->get_abone_regex_add_abone_id();
+}
+
+
+void DBTREE::set_abone_regex_add_abone_id( const std::string& url, const bool set )
+{
+    DBTREE::get_article( url )->set_abone_regex_add_abone_id( set );
 }
 
 

--- a/src/dbtree/interface.h
+++ b/src/dbtree/interface.h
@@ -401,7 +401,8 @@ namespace DBTREE
                       const std::vector< char >& vec_abone_res,
                       const bool transparent, const bool chain, const bool age,
                       const bool default_name, const bool noid,
-                      const bool board, const bool global
+                      const bool board, const bool global,
+                      const bool abone_word_add_abone_id, const bool abone_regex_add_abone_id
         );
 
     // 個別のあぼーん情報のセットと更新
@@ -437,6 +438,14 @@ namespace DBTREE
     // 全体レベルでのあぼーん
     bool get_abone_global( const std::string& url );
     void set_abone_global( const std::string& url, const bool set );
+
+    // ワードであぼーんした投稿者をNG IDに追加する
+    bool get_abone_word_add_abone_id( const std::string& url );
+    void set_abone_word_add_abone_id( const std::string& url, const bool set );
+
+    // 正規表現であぼーんした投稿者をNG IDに追加する
+    bool get_abone_regex_add_abone_id( const std::string& url );
+    void set_abone_regex_add_abone_id( const std::string& url, const bool set );
 
     //　ブックマーク関係
 

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -3263,7 +3263,8 @@ void NodeTreeBase::copy_abone_info( const std::list< std::string >& list_abone_i
                                     const std::unordered_set< int >& abone_reses,
                                     const bool abone_transparent, const bool abone_chain, const bool abone_age,
                                     const bool abone_default_name, const bool abone_noid,
-                                    const bool abone_board, const bool abone_global )
+                                    const bool abone_board, const bool abone_global,
+                                    const bool abone_word_add_abone_id, const bool abone_regex_add_abone_id )
 {
     m_list_abone_id = list_abone_id;
     m_list_abone_name = list_abone_name;
@@ -3310,6 +3311,8 @@ void NodeTreeBase::copy_abone_info( const std::list< std::string >& list_abone_i
     m_abone_noid = abone_noid;
     m_abone_board = abone_board;
     m_abone_global = abone_global;
+    m_abone_word_add_abone_id = abone_word_add_abone_id;
+    m_abone_regex_add_abone_id = abone_regex_add_abone_id;
 }
 
 
@@ -3543,12 +3546,31 @@ bool NodeTreeBase::check_abone_word( const int number )
     JDLIB::Regex regex;
     const size_t offset = 0;
 
+    const char* abone_word_add_idlink = nullptr; // ワードであぼーんした投稿者をNG IDに追加する
+    const char* abone_regex_add_idlink = nullptr; // 正規表現であぼーんした投稿者をNG IDに追加する
+    if( const NODE* idnode = head->headinfo->block[ BLOCK_ID_NAME ]; idnode ) {
+        if( idnode = idnode->next_node; idnode && idnode->linkinfo ) {
+            abone_word_add_idlink = idnode->linkinfo->link;
+        }
+
+        if( m_abone_regex_add_abone_id ) {
+            abone_regex_add_idlink = abone_word_add_idlink;
+        }
+        if( ! m_abone_word_add_abone_id ) {
+            abone_word_add_idlink = nullptr;
+        }
+    }
+
     // ローカル NG word
     if( check_word ){
 
         for( const std::string& word : m_list_abone_word ) {
             if( res_str.find( word ) != std::string::npos ) {
                 head->headinfo->abone = true;
+
+                if( abone_word_add_idlink ) {
+                    DBTREE::add_abone_id( m_url, abone_word_add_idlink );
+                }
                 return true;
             }
         }
@@ -3560,6 +3582,10 @@ bool NodeTreeBase::check_abone_word( const int number )
         for( const JDLIB::RegexPattern& pattern : m_list_abone_regex ) {
             if( regex.match( pattern, res_str, offset ) ){
                 head->headinfo->abone = true;
+
+                if( abone_regex_add_idlink ) {
+                    DBTREE::add_abone_id( m_url, abone_regex_add_idlink );
+                }
                 return true;
             }
         }
@@ -3571,6 +3597,10 @@ bool NodeTreeBase::check_abone_word( const int number )
         for( const std::string& word : m_list_abone_word_board ) {
             if( res_str.find( word ) != std::string::npos ) {
                 head->headinfo->abone = true;
+
+                if( abone_word_add_idlink ) {
+                    DBTREE::add_abone_id( m_url, abone_word_add_idlink );
+                }
                 return true;
             }
         }
@@ -3582,6 +3612,10 @@ bool NodeTreeBase::check_abone_word( const int number )
         for( const JDLIB::RegexPattern& pattern : m_list_abone_regex_board ) {
             if( regex.match( pattern, res_str, offset ) ){
                 head->headinfo->abone = true;
+
+                if( abone_regex_add_idlink ) {
+                    DBTREE::add_abone_id( m_url, abone_regex_add_idlink );
+                }
                 return true;
             }
         }
@@ -3593,6 +3627,10 @@ bool NodeTreeBase::check_abone_word( const int number )
         for( const std::string& word : m_list_abone_word_global ) {
             if( res_str.find( word ) != std::string::npos ) {
                 head->headinfo->abone = true;
+
+                if( abone_word_add_idlink ) {
+                    DBTREE::add_abone_id( m_url, abone_word_add_idlink );
+                }
                 return true;
             }
         }
@@ -3604,6 +3642,10 @@ bool NodeTreeBase::check_abone_word( const int number )
         for( const JDLIB::RegexPattern& pattern : m_list_abone_regex_global ) {
             if( regex.match( pattern, res_str, offset ) ){
                 head->headinfo->abone = true;
+
+                if( abone_regex_add_idlink ) {
+                    DBTREE::add_abone_id( m_url, abone_regex_add_idlink );
+                }
                 return true;
             }
         }

--- a/src/dbtree/nodetreebase.h
+++ b/src/dbtree/nodetreebase.h
@@ -101,6 +101,8 @@ namespace DBTREE
         bool m_abone_noid{}; // ID無しのレスはあぼーん
         bool m_abone_board{}; // 板レベルでのあぼーんを有効にする
         bool m_abone_global{}; // 全体レベルでのあぼーんを有効にする
+        bool m_abone_word_add_abone_id{}; ///< ワードであぼーんした投稿者をNG IDに追加する
+        bool m_abone_regex_add_abone_id{}; ///< 正規表現であぼーんした投稿者をNG IDに追加する
 
         // 自分が書き込んだレスか
         std::unordered_set< int > m_posts;
@@ -257,7 +259,8 @@ namespace DBTREE
                               const std::unordered_set< int >& abone_reses,
                               const bool abone_transparent, const bool abone_chain, const bool abone_age,
                               const bool abone_default_name, const bool abone_noid,
-                              const bool abone_board, const bool abone_global );
+                              const bool abone_board, const bool abone_global,
+                              const bool abone_word_add_abone_id, const bool abone_regex_add_abone_id );
 
         // 全レスのあぼーん状態の更新
         // 発言数や参照数も更新する


### PR DESCRIPTION
**このPRは不採用のアイデアでありマージしません。**

あぼーん設定でNG ワードやNG 正規表現に引っかかったIDを自動的にNG IDに入れる機能をテスト実装します。

スレのプロパティにあるあぼーん設定に以下のチェックボックスを追加します。

- "ワードであぼ〜んした投稿者をNG IDに追加する"
- "正規表現であぼ〜んした投稿者をNG IDに追加する"

https://mao.5ch.net/test/read.cgi/linux/1689151433/436

不採用の理由
自動的にIDを追加したくないワードや正規表現があると設定が両立できないため使い勝手が悪い。