### PR TITLE
[TEST] Update machi.to issue1241 and issue1242

### DIFF
--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -4022,6 +4022,9 @@ bool NodeTreeBase::remove_imenu( std::string& str_link )
             || str_link.compare( host_start, 7, "nun.nu/" ) == 0 ) {
         cut_end = host_start + 7;
     }
+    else if( str_link.compare( host_start, 26, "machi.to/bbs/link.cgi?URL=" ) == 0 ) {
+        cut_end = host_start + 26;
+    }
     else {
         return false;
     }

--- a/src/dbtree/root.cpp
+++ b/src/dbtree/root.cpp
@@ -1593,11 +1593,10 @@ bool Root::is_JBBS( const std::string& url )
 //
 bool Root::is_machi( const std::string& url )
 {
-    const std::string hostname = MISC::get_hostname( url );
+    constexpr bool protocol = false;
+    const std::string hostname = MISC::get_hostname( url, protocol );
 
-    if( hostname.find( ".machi.to" ) != std::string::npos ) return true;
-
-    return false;
+    return MISC::ends_with( hostname, "machi.to" );
 }
 
 

--- a/src/jdlib/miscutil.h
+++ b/src/jdlib/miscutil.h
@@ -273,6 +273,19 @@ namespace MISC
     // Unicode正規化は行わなずバイト列として比較する
     bool starts_with( const char* self, const char* starts );
 
+    /** @brief haystackの末尾がneedleと一致するか
+     *
+     * @param[in] haystack 末尾をチェックする
+     * @param[in] needle   haystackの末尾と一致するか
+     * @retval true  末尾が一致した、またはneedleが空文字列の場合
+     * @retval false 末尾が不一致、またはhaystackがneedleより短い場合
+     */
+    constexpr bool ends_with( std::string_view haystack, std::string_view needle )
+    {
+        return haystack.size() >= needle.size()
+            && haystack.compare( haystack.size() - needle.size(), needle.size(), needle ) == 0;
+    }
+
     // HTMLからform要素を解析してinput,textarea要素の名前と値を返す
     std::vector<FormDatum> parse_html_form_data( const std::string& html );
 

--- a/test/gtest_dbtree_nodetreebase.cpp
+++ b/test/gtest_dbtree_nodetreebase.cpp
@@ -30,6 +30,7 @@ TEST_F(NodeTreeBase_RemoveImenuTest, not_remove)
         { "https://jump.5ch.net/?", "https://jump.5ch.net/?" },
         { "https://jump.2ch.net/?", "https://jump.2ch.net/?" },
         { "https://pinktower.com/", "https://pinktower.com/" },
+        { "http://machi.to/bbs/link.cgi?URL=", "http://machi.to/bbs/link.cgi?URL=" },
     };
 
     std::string buffer;
@@ -126,6 +127,22 @@ TEST_F(NodeTreeBase_RemoveImenuTest, single_jump_2ch_net)
         { "http://jump.2ch.net/?http://foobar.baz", "http://foobar.baz" },
         { "https://jump.2ch.net/?https://foobar.baz", "https://foobar.baz" },
         { "http://jump.2ch.net/?https://foobar.baz", "https://foobar.baz" },
+    };
+
+    std::string buffer;
+    for( auto [input, expect] : test_data ) {
+        buffer.assign( input );
+        EXPECT_TRUE( DBTREE::NodeTreeBase::remove_imenu( buffer ) );
+        EXPECT_EQ( expect, buffer );
+    }
+}
+
+TEST_F(NodeTreeBase_RemoveImenuTest, single_machi_to_bbs_link_cgi)
+{
+    constexpr const char* test_data[][2] = {
+        { "http://machi.to/bbs/link.cgi?URL=https://foobar.baz", "https://foobar.baz" },
+        { "https://machi.to/bbs/link.cgi?URL=http://foobar.baz", "http://foobar.baz" },
+        { "http://machi.to/bbs/link.cgi?URL=foobar.baz", "http://foobar.baz" },
     };
 
     std::string buffer;

--- a/test/gtest_jdlib_miscutil.cpp
+++ b/test/gtest_jdlib_miscutil.cpp
@@ -1404,6 +1404,39 @@ TEST_F(MISC_StartsWith, null_terminated_string)
 }
 
 
+class MISC_EndsWith : public ::testing::Test {};
+
+TEST_F(MISC_EndsWith, empty_haystack_and_needle)
+{
+    EXPECT_TRUE( MISC::ends_with( "", "" ) );
+}
+
+TEST_F(MISC_EndsWith, empty_haystack)
+{
+    EXPECT_FALSE( MISC::ends_with( "", "needle" ) );
+}
+
+TEST_F(MISC_EndsWith, empty_needle)
+{
+    EXPECT_TRUE( MISC::ends_with( "haystack", "" ) );
+}
+
+TEST_F(MISC_EndsWith, hello_world)
+{
+    EXPECT_TRUE( MISC::ends_with( "Hello World", "World" ) );
+}
+
+TEST_F(MISC_EndsWith, too_long_needle)
+{
+    EXPECT_FALSE( MISC::ends_with( "World", "Hello World" ) );
+}
+
+TEST_F(MISC_EndsWith, not_match)
+{
+    EXPECT_FALSE( MISC::ends_with( "quick brown fox", "dogs" ) );
+}
+
+
 class MISC_ParseHtmlFormData : public ::testing::Test {};
 
 TEST_F(MISC_ParseHtmlFormData, empty_html)


### PR DESCRIPTION
**このPRはテストのためマージしません。**

### [IDEA] Implement MISC::ends_with(haystack, needle)
haystackの末尾がneedleと一致するかチェックする文字列の操作を実装します。合わせてテストケースを追加し動作を確認します。

新しい規格のC++20には同等の操作を行うメンバー関数`std::string::ends_with()`や`std::string_view::ends_with()`がありますがJDimが利用する規格はC++17であるため自前で実装します。

### [IDEA] Root: Support machi.to URL without subdomain
まちBBSのURLのうち地方名サブドメインが付いてないURLをまちBBSとして扱うように修正します。まちBBSのURLは地方名サブドメインが付いてるタイプとサブドメインが無いタイプの2種類あります。

例
- `https://tokyo.machi.to/tokyo/`
- `https://machi.to/tokyo/`

#### 参考文献
https://www.machi.to/bbs/read.cgi/tawara/1416672649/65

### [IDEA] Remove link confirmation page for URLs in machi.to threads
まちBBS(machi.to)のスレッドにあるURLからリンク先の確認ページを表示するURLを取り除くように修正します。
まちBBSでofflaw.cgiを使わないモードでスレッドを読み込むと通常リンク(青)をクリックしたときリンク先の確認ページが開かれるようになっていました。

関連のissue: https://github.com/JDimproved/JDim/issues/1241, https://github.com/JDimproved/JDim/issues/1242