### PR TITLE
[TEST] Fix arabic display

### DIFF
--- a/src/article/drawareabase.cpp
+++ b/src/article/drawareabase.cpp
@@ -413,6 +413,7 @@ void DrawAreaBase::init_fontinfo( FONTINFO& fi, std::string& fontname )
                                        - pango_font_metrics_get_underline_position( metrics ) )
                                      * CONFIG::get_adjust_underline_pos() );
     pango_font_metrics_unref( metrics );
+    m_hiragana_baseline = PANGO_PIXELS( m_pango_layout->get_baseline() );
 
     // 左右padding取得
     // マージン幅は真面目にやると大変そうなので文字列 wstr の平均を取る
@@ -2888,12 +2889,13 @@ void DrawAreaBase::render_text_pangolayout( RenderTextArguments& args )
     auto background = PA::create_attr_background( bg.get_red_u(), bg.get_green_u(), bg.get_blue_u() );
 
     m_pango_layout->set_text( Glib::ustring( args.text, args.n_ustr ) );
+    const int baseline_diff = PANGO_PIXELS( m_pango_layout->get_baseline() ) - m_hiragana_baseline;
 
     Pango::AttrList attr;
     attr.insert( foreground );
     attr.insert( background );
     m_pango_layout->set_attributes( attr );
-    cairo_move_to( args.text_cr, args.x, args.y );
+    cairo_move_to( args.text_cr, args.x, args.y - baseline_diff );
     pango_cairo_show_layout( args.text_cr, m_pango_layout->gobj() );
 
     // Pango::Weight属性を使うと文字幅が変わりレイアウトが乱れる
@@ -2902,7 +2904,7 @@ void DrawAreaBase::render_text_pangolayout( RenderTextArguments& args )
         Pango::AttrList overlapping;
         overlapping.insert( foreground );
         m_pango_layout->set_attributes( overlapping );
-        cairo_move_to( args.text_cr, args.x + 1.0, args.y );
+        cairo_move_to( args.text_cr, args.x + 1.0, args.y - baseline_diff );
         pango_cairo_show_layout( args.text_cr, m_pango_layout->gobj() );
     }
 }

--- a/src/article/drawareabase.h
+++ b/src/article/drawareabase.h
@@ -181,6 +181,7 @@ namespace ARTICLE
         int m_defaultfontid{};
         int m_mailfontid{};
         int m_defaultmailfontid{};
+        int m_hiragana_baseline{};
         FONTINFO *m_font{};       // カレントフォント情報
         FONTINFO m_defaultfont{}; // デフォルトフォント情報
         FONTINFO m_aafont{};      // AA用フォント情報

--- a/src/dbtree/nodetreebase.cpp
+++ b/src/dbtree/nodetreebase.cpp
@@ -2762,10 +2762,9 @@ create_multispace:
                     m_parsed_text.push_back( ' ' );
                 }
                 else if( auto uch = g_utf8_get_char( out_char ); 0x600 <= uch && uch < 0x700 ) {
+                    // U+200E Left-to-right mark (LRM)
+                    m_parsed_text.append( "\xE2\x80\x8E" );
 
-                    // アラビア文字をまとめ右横書き(右から左に書く、RTL)に指定する
-                    // U+202B Right-to-left embedding (RLE)
-                    m_parsed_text.append( "\xE2\x80\xAB" );
                     m_parsed_text.append( out_char, n_out );
                     pos += n_in;
                     do {
@@ -2778,9 +2777,6 @@ create_multispace:
                                 pos += n_in;
                             }
                             else {
-                                // U+202C Pop directional formatting (PDF)
-                                m_parsed_text.append( "\xE2\x80\xAC" );
-
                                 m_parsed_text.append( out_char, n_out );
                                 pos += n_in;
                                 break;
@@ -2791,8 +2787,6 @@ create_multispace:
                             pos += 1;
                         }
                         else {
-                            // U+202C Pop directional formatting (PDF)
-                            m_parsed_text.append( "\xE2\x80\xAC" );
                             break;
                         }
                     } while( pos < pos_end );


### PR DESCRIPTION
**このPRはテストのためマージしません。**

### [TEST] NodeTreeBase: Parse arabic chararacter reference

文字参照をデコードする処理を更新してアラビア文字のテキストの前後に双方向テキストの記号を追加します。

位置 | 記号
---  | ---
前   | U+202B Right-to-left embedding (RLE)
後   | U+202C Pop directional formatting (PDF)

### [TEST] NodeTreeBase: Use U+200E Left-to-right mark (LRM)

RLE と PDF でアラビア文字を囲うかわりにアラビア文字のテキストの前にU+200E Left-to-right mark (LRM) を挿入する方法を使います。

### [TEST] DrawAreaBase: Fix text baseline including arabic for PangoLayout mode

PangoLayout を使って文字を描画するモードのときアラビア文字のレイアウトがy座標で下にずれる問題を修正します。

関連のdiscussion: JDimproved/JDim#1367