### PR TITLE
Test snap migrate to gnome 42 2204

### DIFF
--- a/.github/workflows/snapbuild.yml
+++ b/.github/workflows/snapbuild.yml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: FSFAP
+name: Snap Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      snap-file: ${{ steps.build-snap.outputs.snap }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: snapcore/action-build@v1
+      id: build-snap
+
+    - run: |
+        sudo snap install --dangerous ${{ steps.build-snap.outputs.snap }}
+    - run: |
+        jdim --version
+    - uses: actions/upload-artifact@v3
+      with:
+        name: jdim
+        path: ${{ steps.build-snap.outputs.snap }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,22 +4,21 @@ adopt-info: jdim
 license: "GPL-2.0"
 
 confinement: strict
-base: core20
+base: core22
 grade: stable
 icon: jdim.png
 
-# https://snapcraft.io/gnome-3-38-2004
-# Snap Store does not provide gnome-3-38-2004 package for i386, ppc64el and s390x
+# https://snapcraft.io/gnome-42-2204
+# Snap Store does not provide gnome-42-2204 package for i386, ppc64el and s390x
 architectures:
   - build-on: amd64
-    run-on: amd64
+    build-for: amd64
   - build-on: arm64
-    run-on: arm64
+    build-for: arm64
   - build-on: armhf
-    run-on: armhf
+    build-for: armhf
 
-# https://forum.snapcraft.io/t/supported-extensions/20521
-# https://forum.snapcraft.io/t/the-gnome-3-38-extension/22923
+# https://snapcraft.io/docs/gnome-extension
 parts:
   jdim:
     plugin: meson
@@ -35,18 +34,15 @@ parts:
       - -Dbuild_tests=disabled
       - -Dcompat_cache_dir=disabled
       - -Dpangolayout=enabled
-      - -Dpackager="Snap (JDimproved project)"
+      - "-Dpackager=Snap (JDimproved project)"
     build-environment:
       # https://wiki.debian.org/Hardening
       - DEB_BUILD_MAINT_OPTIONS: "hardening=+all"
       # Use -isystem to suppress compiler warning:
-      # /snap/gnome-3-38-2004-sdk/current/usr/include/limits.h:124:3: warning: #include_next is a GCC extension
-      - CPPFLAGS: "$(dpkg-buildflags --get CPPFLAGS) -isystem /snap/gnome-3-38-2004-sdk/current/usr/include"
+      # /snap/gnome-42-2204-sdk/current/usr/include/limits.h:124:3: warning: #include_next is a GCC extension
+      - CPPFLAGS: "$(dpkg-buildflags --get CPPFLAGS) -isystem /snap/gnome-42-2204-sdk/current/usr/include"
       - CXXFLAGS: "$(dpkg-buildflags --get CXXFLAGS)"
       - LDFLAGS: "$(dpkg-buildflags --get LDFLAGS)"
-    build-packages:
-      - libgnutls28-dev
-      - libsigc++-2.0-dev
     override-build: |
       set -eu
       snapcraftctl build
@@ -65,7 +61,7 @@ apps:
     command: bin/jdim
     common-id: com.github.jdimproved.jdim
     desktop: share/applications/jdim.desktop
-    extensions: [gnome-3-38]
+    extensions: [gnome]
     plugs:
       - home
       - network


### PR DESCRIPTION
**このPRはテストのためマージしません。**

### [TEST] snap: Migrate base to core22

snapのbaseをcore22に変更して[gnome extension][1](gnome-42-2204)に移行します。

対応CPUアーキテクチャ: amd64, arm64, armhf

[1]: https://snapcraft.io/docs/gnome-extension

### [TEST] Add GitHub actions workflow snapbuild

Snapパッケージをビルドして成果物として保存するアクションを追加します。
workflowの実行は手動でトリガーします。

参考文献:
https://ubuntu.com/robotics/docs/build-and-publish-a-ros-snap-with-github-actions
