### PR TITLE
[TEST] Apply Wayland popup positioning logic to X11

### DIFF
--- a/src/skeleton/popupwin.cpp
+++ b/src/skeleton/popupwin.cpp
@@ -51,12 +51,15 @@ void PopupWin::slot_resize_popup()
 {
     if( ! m_view ) return;
 
+    move_resize_wayland();
+#if 0
     if( m_running_on_wayland ) {
         move_resize_wayland();
     }
     else {
         move_resize_conventional();
     }
+#endif
     show_all();
 }
 
@@ -70,12 +73,15 @@ void PopupWin::slot_realize()
 {
     if( ! m_view ) return;
 
+    move_resize_wayland();
+#if 0
     if( m_running_on_wayland ) {
         move_resize_wayland();
     }
     else {
         move_resize_conventional();
     }
+#endif
 }
 
 
@@ -247,6 +253,11 @@ void PopupWin::move_resize_wayland()
         // ウインドウを非表示にして呼び出さないと期待通り動作しない環境がある
         // https://gitlab.gnome.org/GNOME/gtk/-/issues/1986
         hide();
+    }
+    else if( ! m_running_on_wayland ) {
+        // X11環境では、viewの自然なサイズからウインドウの幅と高さを計算すると、
+        // 高さが大きい場合に期待通り動作しないことがあるため、幅と高さを明示的に指定します。
+        set_default_size( width_client, height_popup );
     }
     gdk_window_move_to_rect( get_window()->gobj(), &rect_dest, rect_anchor, window_anchor, anchor_hints,
                              rect_anchor_dx, rect_anchor_dy );

--- a/src/skeleton/popupwin.cpp
+++ b/src/skeleton/popupwin.cpp
@@ -198,6 +198,10 @@ void PopupWin::move_resize_wayland()
     monitor->get_workarea( rect );
     const int height_desktop = rect.get_height();
 
+    // 作業領域上のマウス座標を計算する。
+    const int y_desktop = rect.get_y();
+    const int y_mouse_local = y_mouse - y_desktop;
+
     // クライアントのサイズを取得
     const int height_client = m_view->height_client();
     const int width_client = m_view->width_client();
@@ -210,27 +214,26 @@ void PopupWin::move_resize_wayland()
     GdkGravity rect_anchor; // 表示位置の角
     GdkGravity window_anchor; // ポップアップの角
     int height_popup; // ポップアップ表示中にリサイズするとき使う
-    if( y_mouse - ( height_client + m_mrg_y ) >= 0 ) { // 上にスペースがある
+    if( y_mouse_local - ( height_client + m_mrg_y ) >= 0 ) { // 上にスペースがある
         rect_anchor = GDK_GRAVITY_NORTH_WEST;
         window_anchor = GDK_GRAVITY_SOUTH_WEST;
         height_popup = height_client;
     }
-    else if( y_mouse + m_mrg_y + height_client <= height_desktop ) { // 下にスペースがある
+    else if( y_mouse_local + m_mrg_y + height_client <= height_desktop ) { // 下にスペースがある
         rect_anchor = GDK_GRAVITY_SOUTH_WEST;
         window_anchor = GDK_GRAVITY_NORTH_WEST;
         height_popup = height_client;
     }
-    else if( m_view->get_popup_upside() || y_mouse > height_desktop / 2 ) { // スペースは無いが上に表示
+    else if( m_view->get_popup_upside() || y_mouse_local > height_desktop / 2 ) { // スペースは無いが上に表示
         rect_anchor = GDK_GRAVITY_NORTH_WEST;
         window_anchor = GDK_GRAVITY_SOUTH_WEST;
-        const int y_popup = (std::max)( 0, y_mouse - ( height_client + m_mrg_y ) );
-        height_popup = y_mouse - ( y_popup + m_mrg_y );
+        const int y_popup = y_desktop + (std::max)( 0, y_mouse_local - ( height_client + m_mrg_y ) );
+        height_popup = y_mouse_local - ( y_popup - y_desktop + m_mrg_y );
     }
     else { // スペースは無いが下に表示
         rect_anchor = GDK_GRAVITY_SOUTH_WEST;
         window_anchor = GDK_GRAVITY_NORTH_WEST;
-        const int y_popup = y_mouse + m_mrg_y;
-        height_popup = height_desktop - y_popup;
+        height_popup = height_desktop - ( y_mouse_local + m_mrg_y );
     }
 
     // 3. リサイズと移動を行う


### PR DESCRIPTION
### [[TEST] Apply Wayland popup positioning logic to X11](https://github.com/ma8ma/JDim/commit/3006553e936ed258711cd770ba9e059918427403)

Wayland環境のポップアップ配置ロジックをX11環境にも適用します。

このパッチは親ウィンドウの左上を原点としてポップアップの位置を決定し、2つのウィンドウの相対的な座標で配置します。これにより、モニターの画面領域を考慮した座標計算がY方向のみで済むようになります(マウスポインターの上と下どちらにポップアップを配置するかの判断など)。

Waylandでは、SKELETON::Viewの自然な幅・高さを基にGTK/GDKがポップアップサイズを計算しますが、X11環境では高さが大きい場合に期待通りに動作しないことがあります。このため、ポップアップ表示中にリサイズ時の高さを明示的に指定するよう変更しました。

### [ポップアップの位置判定に使用するマウス座標を作業領域上の座標に変換するように修正](https://github.com/ma8ma/JDim/commit/51988ae3667fd80688961c44951003bd72db45ce)

@mokeke-maru さんの修正をWaylandのポップアップ配置処理に追加します。
