### PR TITLE
[TEST] Fix failing muon-master job in GitHub Actions Weekly CI

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -81,7 +81,7 @@ jobs:
       - name: build muon stage2
         run: |
           cd muon-src
-          ./stage1/muon-bootstrap setup -Ddocs=disabled -Dlibarchive=disabled -Dlibcurl=disabled -Dlibpkgconf=enabled ../muon-build
+          ./stage1/muon-bootstrap setup -Dman-pages=disabled -Dmeson-docs=disabled -Dmeson-tests=disabled -Dlibarchive=disabled -Dlibcurl=disabled -Dlibpkgconf=enabled ../muon-build
           ./stage1/muon-bootstrap samu -C ../muon-build
           cd ..
       - run: ./muon-build/muon version


### PR DESCRIPTION
GitHub Actions のWeekly CI で、muon-master ジョブが Muon リビジョン f94e3c889238d0642cfaebdf6905f2ad88db1065 (2025-03-14) 以降のビルドオプションの変更の影響で失敗していたため、対応します。
この変更により、 `docs` ビルドオプションが `man-pages`, `meson-docs`, `meson-tests` に分割されたためそれぞれのオプションを `disabled` に設定することで正常にジョブが完了するようにします。

関連のissue: https://github.com/JDimproved/JDim/issues/1533
