### PR TITLE
[TEST] snap: build-on amd64 and build-for riscv64

### DIFF
--- a/.github/workflows/snapbuild.yaml
+++ b/.github/workflows/snapbuild.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: FSFAP
+name: Snap Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      snap-file: ${{ steps.build-snap.outputs.snap }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: snapcore/action-build@v1
+      id: build-snap
+
+    - run: |
+        sudo snap install --dangerous ${{ steps.build-snap.outputs.snap }}
+    - run: |
+        jdim --version
+    - uses: actions/upload-artifact@v4
+      with:
+        name: jdim
+        path: ${{ steps.build-snap.outputs.snap }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,11 +12,12 @@ icon: jdim.png
 # Snap Store does not provide gnome-42-2204 package for i386, ppc64el and s390x
 architectures:
   - build-on: amd64
-    build-for: amd64
+    build-for: [amd64, riscv64]
   - build-on: arm64
     build-for: arm64
   - build-on: armhf
-    build-for: armhf
+  - build-on: riscv64
+    build-for: riscv64
 
 # https://snapcraft.io/docs/gnome-extension
 parts:


### PR DESCRIPTION
**このPRはマージしません。**

### [TEST] snap: build-on amd64 and build-for riscv64

[2025-03-31][1]以降、gnome extension([gnome-42-2204][2])は stable
チャンネルで利用可能な CPU アーキテクチャに riscv64 が追加されました。

このテストでは以下をチェックします。

- amd64 環境で riscv64 向けsnapパッケージをビルドできる
- riscv64 環境で riscv64 向けsnapパッケージをビルドする構成が構文エラーにならないこと。

[1]: https://github.com/ubuntu/gnome-sdk/issues/285
[2]: https://snapcraft.io/docs/gnome-extension

### [TEST] Add GitHub actions workflow snapbuild

Snapパッケージをビルドして成果物として保存するアクションを追加します。
workflowの実行は手動でトリガーします。

参考文献:
https://ubuntu.com/robotics/docs/build-and-publish-a-ros-snap-with-github-actions

