### PR TITLE
[TEST] Update CI settings

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -40,24 +40,12 @@ jobs:
     strategy:
       matrix:
         sets:
-          - cc: gcc-10
-            cxx: g++-10
-            package: g++-10
           - cc: gcc-11
             cxx: g++-11
             package: g++-11
           - cc: gcc-12
             cxx: g++-12
             package: g++-12
-          - cc: clang-11
-            cxx: clang++-11
-            package: clang-11
-          - cc: clang-12
-            cxx: clang++-12
-            package: clang-12
-          - cc: clang-13
-            cxx: clang++-13
-            package: clang-13
           - cc: clang-14
             cxx: clang++-14
             package: clang-14
@@ -83,6 +71,9 @@ jobs:
     strategy:
       matrix:
         sets:
+          - cc: gcc-12
+            cxx: g++-12
+            package: g++-12
           - cc: gcc-13
             cxx: g++-13
             package: g++-13
@@ -98,6 +89,12 @@ jobs:
           - cc: clang-18
             cxx: clang++-18
             package: clang-18
+          - cc: clang-19
+            cxx: clang++-19
+            package: clang-19
+          - cc: clang-20
+            cxx: clang++-20
+            package: clang-20
     steps:
       - uses: actions/checkout@v4
       - name: dependencies installation


### PR DESCRIPTION
**このPRはCIの確認用です。マージしません。**

コンパイラ対応とオプションのライブラリを確認するためGitHub Actionsを利用してCI設定を構成します。[20 jobs][*]を超えると実行待機が発生するため廃止予定オプションとコンパイラオプションはテストから除外しています。ディストロとツールチェーンの組み合わせも網羅していません。

コンパイラ: gcc-11 ~ gcc-14, clang-14 ~ clang-20
ディストロ: Ubuntu22.04, Ubuntu24.04
ビルドツール: Meson

AddressSanitizerを有効にしたビルド (1 job)
Ubuntu24.04

- gcc-13

コンパイラーを変更するビルド (12 jobs)
Ubuntu22.04

- gcc-11
- gcc-12
- clang-14
- clang-15

Ubuntu24.04

- gcc-12
- gcc-13
- gcc-14
- clang-16
- clang-17
- clang-18
- clang-19
- clang-20

オプションのビルド (6 jobs)
Ubuntu22.04

- gnutls, sessionlib=xsmp, migemo, alsa, pangolayout
- openssl, sessionlib=no, migemo, compat_cache_dir=disabled
- openssl, sessionlib=xsmp, alsa, pangolayout

Ubuntu24.04

- gnutls, sessionlib=xsmp, migemo, alsa, pangolayout
- openssl, sessionlib=no, migemo, compat_cache_dir=disabled
- openssl, sessionlib=xsmp, alsa, pangolayout

マニュアルのビルド (1 job)

[*]: https://docs.github.com/en/free-pro-team@latest/actions/reference/usage-limits-billing-and-administration#usage-limits
