### PR TITLE
WIP: GTKMM4 migration

### DIFF
--- a/.github/scripts/analyze_gcc_json.py
+++ b/.github/scripts/analyze_gcc_json.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""
+gcc のコンパイラーオプション -fdiagnostics-format=json-file を使ってビルドすると生成される
+jsonファイルを解析しエラーを分類、カウントしてMarkdown形式で標準出力に書き出すスクリプト
+"""
+
+import glob
+import json
+import os
+import sys
+from collections import Counter
+
+
+def parse_gcc_json_files(json_dir):
+    warnings = Counter()
+    errors = Counter()
+    analyzed_files = 0
+
+    # builddir 配下の全 json ファイルを探す
+    json_files = glob.glob(os.path.join(json_dir, "**", "*.gcc.json"), recursive=True)
+
+    for file_path in json_files:
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                # GCCのJSONはトップレベルがリスト構造
+                for diag in data:
+                    kind = diag.get("kind")
+                    raw_option = diag.get("option")
+                    message = diag.get("message", "")
+
+                    if kind == "warning":
+                        # [-Wdeprecated-declarations] などの警告フラグごとにカウント
+                        # 警告フラグ + メッセージの簡易分類
+                        if raw_option:
+                            key = raw_option
+                        elif message:
+                            key = message.split("\n")[0][:80]
+                        else:
+                            key = "other-error/warning"
+                        warnings[key] += 1
+                    elif kind == "error":
+                        # エラーはメッセージの先頭部分等で分類
+                        short_msg = (
+                            message.split("\n")[0][:60] if message else "Unknown Error"
+                        )
+                        errors[short_msg] += 1
+            analyzed_files += 1
+        except (ValueError, OSError) as e:
+            # 万が一読み込みに失敗してもスキップ
+            print(f"Failed to parse {file_path}: {e}", file=sys.stderr)
+            continue
+
+    return warnings, errors, analyzed_files
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit("usage: analyze_gcc_json.py json_dir")
+
+    json_dir = sys.argv[1]
+    warnings, errors, analyzed_files = parse_gcc_json_files(json_dir)
+
+    # Markdown 形式で出力
+    print("## 📊 GTKMM4 Migration Diagnostics\n")
+    print(f"* JSON files analyzed: {analyzed_files}")
+    print(f"* Diagnostics analyzed: {sum(warnings.values()) + sum(errors.values())}\n")
+
+    print("### ❌ Errors\n")
+    if errors:
+        print("| Count | Error Summary |\n|---|---|")
+        for err, count in errors.most_common():
+            print(f"| {count} | `{err}` |")
+    else:
+        print("No errors found! 🎉\n\n")
+
+    print("\n### ⚠️ Warnings\n")
+    if warnings:
+        print("| Count | Warning Flag |\n|---|---|")
+        for warn, count in warnings.most_common():
+            print(f"| {count} | `{warn}` |")
+    else:
+        print("No warnings found!")

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,13 +1,16 @@
 # SPDX-License-Identifier: FSFAP
 name: CI
 
+# gtkmm4-migration ブランチでのGTKMM4移行作業中は通常CIの自動実行を停止する。（手動実行のみ許可）
+# 移行完了後にpush/pull_requestのトリガーを復元する。
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  workflow_dispatch:
+  #push:
+  #  branches:
+  #    - master
+  #pull_request:
+  #  branches:
+  #    - master
 
 jobs:
 

--- a/.github/workflows/gtkmm4-migration.yml
+++ b/.github/workflows/gtkmm4-migration.yml
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: FSFAP
+name: GTKMM4 migration
+
+on:
+  push:
+    branches:
+      - gtkmm4-migration
+  pull_request:
+    branches:
+      - gtkmm4-migration
+  workflow_dispatch:
+
+# * 移行作業の修正が既存のビルド構成を壊していないかチェックする。
+# * use_gtkmm4=true をつけて移行作業の修正をビルドしてチェックする。
+jobs:
+
+  ASan-24:
+    runs-on: ubuntu-24.04
+    env:
+      CC: gcc-13
+      CXX: g++-13
+      # Avoid crash for calling crypt_r() that is pointing invalid address.
+      # https://github.com/JDimproved/JDim/issues/943
+      AVOID_CRASH: -Wl,--push-state,--no-as-needed -lcrypt -Wl,--pop-state
+    steps:
+      - uses: actions/checkout@v7
+      - name: dependencies installation
+        run: |
+          sudo apt update
+          sudo apt install libcrypt-dev libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev g++-13
+      - run: meson setup builddir -Duse_gtkmm4=false -Db_sanitize=address,undefined -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dcpp_link_args="${AVOID_CRASH}"
+        # `compile` subcommand requires Meson 0.54 or later.
+      - run: ninja -C builddir
+        # Since Meson 0.57, `test` subcommand will only rebuild test program.
+      - run: meson test -v -C builddir
+      - run: ./builddir/src/jdim -V
+
+  compiler-22:
+    runs-on: ubuntu-22.04
+    env:
+      CC: ${{ matrix.sets.cc }}
+      CXX: ${{ matrix.sets.cxx }}
+    strategy:
+      matrix:
+        sets:
+          - cc: gcc-11
+            cxx: g++-11
+            package: g++-11
+    steps:
+      - uses: actions/checkout@v7
+      - name: dependencies installation
+        run: |
+          sudo apt update
+          sudo apt install libcrypt-dev libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev ${{ matrix.sets.package }}
+      - run: meson setup builddir -Duse_gtkmm4=false -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
+      - run: ninja -C builddir
+      - run: meson test -v -C builddir
+      - run: ./builddir/src/jdim -V
+
+  compiler-24:
+    runs-on: ubuntu-24.04
+    env:
+      CC: ${{ matrix.sets.cc }}
+      CXX: ${{ matrix.sets.cxx }}
+    strategy:
+      matrix:
+        sets:
+          - cc: gcc-13
+            cxx: g++-13
+            package: g++-13
+          - cc: clang-18
+            cxx: clang++-18
+            package: clang-18
+    steps:
+      - uses: actions/checkout@v7
+      - name: dependencies installation
+        run: |
+          sudo apt update
+          sudo apt install libcrypt-dev libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev ${{ matrix.sets.package }}
+      - run: meson setup builddir -Duse_gtkmm4=false -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
+      - run: ninja -C builddir
+      - run: meson test -v -C builddir
+      - run: ./builddir/src/jdim -V
+
+  library-22:
+    runs-on: ubuntu-22.04
+    env:
+      CC: gcc-11
+      CXX: g++-11
+    strategy:
+      matrix:
+        deps:
+          - config_args: -Dtls=gnutls -Dsessionlib=xsmp -Dmigemo=enabled -Dalsa=enabled -Dpangolayout=enabled
+            packages: libgnutls28-dev libmigemo-dev libasound2-dev
+          - config_args: -Dtls=openssl -Dsessionlib=no -Dmigemo=enabled -Dcompat_cache_dir=disabled
+            packages: libssl-dev libmigemo-dev
+          - config_args: -Dtls=openssl -Dsessionlib=xsmp -Dalsa=enabled -Dpangolayout=enabled
+            packages: libssl-dev libasound2-dev
+    steps:
+      - uses: actions/checkout@v7
+      - name: dependencies installation (${{ matrix.deps.packages }})
+        run: |
+          sudo apt update
+          sudo apt install libcrypt-dev meson libgtest-dev libgtkmm-3.0-dev ${{ matrix.deps.packages }} g++-11
+      - run: meson setup builddir -Duse_gtkmm4=false -Dbuildtype=debug -Dcpp_args="-D_DEBUG" ${{ matrix.deps.config_args }}
+      - run: ninja -C builddir
+      - run: meson test -v -C builddir
+      - run: ./builddir/src/jdim -V
+
+  library-24:
+    runs-on: ubuntu-24.04
+    env:
+      CC: gcc-13
+      CXX: g++-13
+    strategy:
+      matrix:
+        deps:
+          - config_args: -Dtls=gnutls -Dsessionlib=xsmp -Dmigemo=enabled -Dalsa=enabled -Dpangolayout=enabled
+            packages: libgnutls28-dev libmigemo-dev libasound2-dev
+          - config_args: -Dtls=openssl -Dsessionlib=no -Dmigemo=enabled -Dcompat_cache_dir=disabled
+            packages: libssl-dev libmigemo-dev
+          - config_args: -Dtls=openssl -Dsessionlib=xsmp -Dalsa=enabled -Dpangolayout=enabled
+            packages: libssl-dev libasound2-dev
+    steps:
+      - uses: actions/checkout@v7
+      - name: dependencies installation (${{ matrix.deps.packages }})
+        run: |
+          sudo apt update
+          sudo apt install libcrypt-dev meson libgtest-dev libgtkmm-3.0-dev ${{ matrix.deps.packages }} g++-13
+      - run: meson setup builddir -Duse_gtkmm4=false -Dbuildtype=debug -Dcpp_args="-D_DEBUG" ${{ matrix.deps.config_args }}
+      - run: ninja -C builddir
+      - run: meson test -v -C builddir
+      - run: ./builddir/src/jdim -V
+
+  manual-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./docs/_site
+
+  Unity-build-gcc14-Werror:
+    runs-on: ubuntu-24.04
+    env:
+      CC: gcc-14
+      CXX: g++-14
+    steps:
+      - uses: actions/checkout@v7
+      - name: dependencies installation
+        run: |
+          sudo apt update
+          sudo apt install libcrypt-dev libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev g++-14
+      - run: meson setup builddir -Duse_gtkmm4=false -Dunity=on -Dunity_size=1000 -Dbuildtype=debug -Dcpp_args="-D_DEBUG" -Dwerror=true
+      - run: ninja -C builddir -k0
+      - run: meson test -v -C builddir
+      - run: ./builddir/src/jdim -V
+
+  gtkmm4-migration:
+    runs-on: ubuntu-24.04
+    env:
+      CC: ${{ matrix.sets.cc }}
+      CXX: ${{ matrix.sets.cxx }}
+    strategy:
+      fail-fast: false
+      matrix:
+        sets:
+          - cc: gcc-13
+            cxx: g++-13
+            package: g++-13
+          - cc: clang-18
+            cxx: clang++-18
+            package: clang-18
+    steps:
+      - uses: actions/checkout@v7
+      - name: dependencies installation
+        run: |
+          sudo apt update
+          sudo apt install libcrypt-dev libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev ${{ matrix.sets.package }}
+      - run: meson setup builddir -Duse_gtkmm4=true -Dbuildtype=debug -Dcpp_args="-D_DEBUG"
+      - name: Build with GTKMM4 migration
+        # GTKMM4移行初期ではビルド失敗は意図したものなので、
+        # ビルドに失敗してもJobを成功扱いとして後続処理を続行する。
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          ninja -C builddir -k0 2>&1 | tee build.log
+      - name: Upload build log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: gtkmm4-build-log-${{ matrix.sets.package || 'default' }}
+          path: build.log
+          retention-days: 7
+
+  gtkmm4-gcc13-json:
+    runs-on: ubuntu-24.04
+    env:
+      CC: ${{ matrix.sets.cc }}
+      CXX: ${{ matrix.sets.cxx }}
+    strategy:
+      matrix:
+        sets:
+          - cc: gcc-13
+            cxx: g++-13
+            package: g++-13
+    steps:
+      - uses: actions/checkout@v7
+      - name: dependencies installation
+        run: |
+          sudo apt update
+          sudo apt install libcrypt-dev libgnutls28-dev libgtest-dev libgtkmm-3.0-dev meson zlib1g-dev ${{ matrix.sets.package }}
+      - run: meson setup builddir -Duse_gtkmm4=true -Dbuildtype=debug -Dcpp_args="-fdiagnostics-format=json-file -D_DEBUG"
+      - name: Build with GTKMM4 migration
+        # GTKMM4移行初期ではビルド失敗は意図したものなので、
+        # ビルドに失敗してもJobを成功扱いとして後続処理を続行する。
+        continue-on-error: true
+        run: ninja -C builddir -k0
+      - name: Collect JSON diagnostics
+        if: always()
+        run: |
+          find builddir -type f -name "*.gcc.json" -print0 | tar czf diagnostics-json.tar.gz --null -T -
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: gcc-json-diagnostics
+          path: diagnostics-json.tar.gz
+          retention-days: 7
+
+  analyze-gcc13-diagnostics:
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    needs: gtkmm4-gcc13-json
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v7
+        with:
+          name: gcc-json-diagnostics
+      - name: Analyze diagnostics
+        run: |
+          tar xzf diagnostics-json.tar.gz
+          python3 .github/scripts/analyze_gcc_json.py . > summary.md
+          cat summary.md
+          cat summary.md >> $GITHUB_STEP_SUMMARY
+      - name: Upload summary
+        uses: actions/upload-artifact@v7
+        with:
+          name: diagnostics-summary
+          path: summary.md
+          retention-days: 7

--- a/.github/workflows/gtkmm4-migration.yml
+++ b/.github/workflows/gtkmm4-migration.yml
@@ -5,10 +5,13 @@ on:
   push:
     branches:
       - gtkmm4-migration
-  pull_request:
-    branches:
-      - gtkmm4-migration
+      - 'gtkmm4-migration/**' # 派生ブランチを作った場合もカバー
   workflow_dispatch:
+
+# 連投 Push 時に古い CI ジョブを自動キャンセルしてキューの詰まりを防ぐ
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 # * 移行作業の修正が既存のビルド構成を壊していないかチェックする。
 # * use_gtkmm4=true をつけて移行作業の修正をビルドしてチェックする。

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@
 #   - 生成された実行ファイルの場所は builddir/src/jdim
 
 project('jdim', 'cpp',
-        version : '0.17.1-alpha',
+        version : '0.17.90-alpha',
         license : 'GPL2',
         meson_version : '>= 0.61.0',
         default_options : ['warning_level=3', 'cpp_std=c++20'])

--- a/meson.build
+++ b/meson.build
@@ -220,9 +220,10 @@ endif
 # GTKMM4移行準備: 廃止予定APIをエラーにする
 #
 if get_option('use_gtkmm4')
-  conf.set('USE_GTKMM4', 1)
+  # GTKMM4移行ビルドは USE_GTKMM4 を定義する
   # 廃止予定機能が使われていたらコンパイルエラーにするマクロを定義する
   add_project_arguments(
+    '-DUSE_GTKMM4',
     '-DGDKMM_DISABLE_DEPRECATED',
     '-DGDK_DISABLE_DEPRECATED',
     '-DGIOMM_DISABLE_DEPRECATED',

--- a/meson.build
+++ b/meson.build
@@ -217,6 +217,24 @@ endif
 
 
 #
+# GTKMM4移行準備: 廃止予定APIをエラーにする
+#
+if get_option('use_gtkmm4')
+  conf.set('USE_GTKMM4', 1)
+  # 廃止予定機能が使われていたらコンパイルエラーにするマクロを定義する
+  add_project_arguments(
+    '-DGDKMM_DISABLE_DEPRECATED',
+    '-DGDK_DISABLE_DEPRECATED',
+    '-DGIOMM_DISABLE_DEPRECATED',
+    '-DGLIBMM_DISABLE_DEPRECATED',
+    '-DGTKMM_DISABLE_DEPRECATED',
+    '-DGTK_DISABLE_DEPRECATED',
+    language: 'cpp',
+  )
+endif
+
+
+#
 # ビルドの情報
 #
 conf.set('HAVE_BUILDINFO_H', 1)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,3 +10,4 @@ option('packager', type : 'string', value : '', description : 'String identifyin
 option('pangolayout', type : 'feature', value : 'disabled', description : 'Render text by PangoLayout')
 option('sessionlib', type : 'combo', choices : ['xsmp', 'no'], value : 'xsmp', description : 'Use Session Management Protocol')
 option('tls', type : 'combo', choices : ['gnutls', 'openssl'], value : 'gnutls', description : 'SSL/TLS library to use')
+option('use_gtkmm4', type : 'boolean', value : false, description : 'Use GTKMM4 for GUI library (WIP)')

--- a/src/bbslist/addetcdialog.cpp
+++ b/src/bbslist/addetcdialog.cpp
@@ -21,10 +21,17 @@ AddEtcDialog::AddEtcDialog( const bool move, const std::string& url, const std::
 {
     set_default_size( 600, -1 );
 
+#ifdef USE_GTKMM4
+    m_label_name.set_xalign( 0.0 );
+    m_label_url.set_xalign( 0.0 );
+    m_label_id.set_xalign( 0.0 );
+    m_label_pw.set_xalign( 0.0 );
+#else
     m_label_name.set_alignment( Gtk::ALIGN_START );
     m_label_url.set_alignment( Gtk::ALIGN_START );
     m_label_id.set_alignment( Gtk::ALIGN_START );
     m_label_pw.set_alignment( Gtk::ALIGN_START );
+#endif
 
     m_label_name.set_mnemonic_widget( m_entry_name );
     m_label_url.set_mnemonic_widget( m_entry_url );
@@ -102,8 +109,13 @@ AddEtcBBSMenuDialog::AddEtcBBSMenuDialog( Gtk::Window* parent, const bool edit,
 {
     set_default_size( 600, -1 );
 
+#ifdef USE_GTKMM4
+    m_label_name.set_xalign( 0.0 );
+    m_label_url.set_xalign( 0.0 );
+#else
     m_label_name.set_alignment( Gtk::ALIGN_START );
     m_label_url.set_alignment( Gtk::ALIGN_START );
+#endif
     m_label_name.set_mnemonic_widget( m_entry_name );
     m_label_url.set_mnemonic_widget( m_entry_url );
 

--- a/src/control/mousekeypref.cpp
+++ b/src/control/mousekeypref.cpp
@@ -273,6 +273,9 @@ MouseKeyDiag::MouseKeyDiag( Gtk::Window* parent, const std::string& url,
     , m_button_delete( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Delete", 12 ), true )
     , m_button_add( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Add", 12 ), true )
     , m_button_reset( "デフォルト" )
+#ifdef USE_GTKMM4
+    , m_vbuttonbox{ Gtk::ORIENTATION_VERTICAL, 4 }
+#endif
 {
     m_liststore = Gtk::ListStore::create( m_columns );
     m_treeview.set_model( m_liststore );
@@ -293,8 +296,12 @@ MouseKeyDiag::MouseKeyDiag( Gtk::Window* parent, const std::string& url,
     m_vbuttonbox.pack_start( m_button_delete, Gtk::PACK_SHRINK );
     m_vbuttonbox.pack_start( m_button_add, Gtk::PACK_SHRINK );
     m_vbuttonbox.pack_start( m_button_reset, Gtk::PACK_SHRINK );
+#ifdef USE_GTKMM4
+    m_vbuttonbox.set_valign( Gtk::ALIGN_START );
+#else
     m_vbuttonbox.set_layout( Gtk::BUTTONBOX_START );
     m_vbuttonbox.set_spacing( 4 );
+#endif
 
     m_hbox.pack_start( m_scrollwin, Gtk::PACK_EXPAND_WIDGET );
     m_hbox.pack_start( m_vbuttonbox, Gtk::PACK_SHRINK );

--- a/src/control/mousekeypref.h
+++ b/src/control/mousekeypref.h
@@ -98,7 +98,11 @@ namespace CONTROL
         Gtk::Button m_button_delete;
         Gtk::Button m_button_add;
         Gtk::Button m_button_reset;
+#ifdef USE_GTKMM4
+        Gtk::Box m_vbuttonbox;
+#else
         Gtk::VButtonBox m_vbuttonbox;
+#endif
 
         Gtk::HBox m_hbox;
 

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1753,6 +1753,19 @@ bool Core::open_color_diag( std::string title, int id )
 {
     Gdk::RGBA color( CONFIG::get_color( id ) );
 
+#ifdef USE_GTKMM4
+    // TODO: GTK4 - ColorChooserDialog も GTK 4.10 以降 deprecated になる。 Gtk::ColorDialog へ移行する。
+    // ColorChooserDialog ではKDE環境のスポイトが利用できない
+    Gtk::ColorChooserDialog diag( title );
+    diag.set_use_alpha( false );
+    diag.set_rgba( color );
+    diag.set_transient_for( *CORE::get_mainwindow() );
+    if( diag.run() == Gtk::RESPONSE_OK ){
+        color = diag.get_rgba();
+        CONFIG::set_color( id, MISC::color_to_str( color ) );
+        return true;
+    }
+#else
     Gtk::ColorSelectionDialog diag( title );
     diag.get_color_selection()->set_current_rgba( color );
     diag.set_transient_for( *CORE::get_mainwindow() );
@@ -1761,6 +1774,7 @@ bool Core::open_color_diag( std::string title, int id )
         CONFIG::set_color( id, MISC::color_to_str( sel->get_current_rgba() ) );
         return true;
     }
+#endif
 
     return false;
 }

--- a/src/fontcolorpref.cpp
+++ b/src/fontcolorpref.cpp
@@ -657,11 +657,21 @@ void FontColorPref::slot_change_color()
         if( colorid == COLOR_NONE ) return;
     }
 
+#ifdef USE_GTKMM4
+    // TODO: GTK4 - ColorChooserDialog も GTK 4.10 以降 deprecated になる。 Gtk::ColorDialog へ移行する。
+    // ColorChooserDialog ではKDE環境のスポイトが利用できない
+    Gtk::ColorChooserDialog colordiag;
+    colordiag.set_use_alpha( false );
+    if( colorid != COLOR_NONE ) {
+        colordiag.set_rgba( Gdk::RGBA( CONFIG::get_color( colorid ) ) );
+    }
+#else
     Gtk::ColorSelectionDialog colordiag;
     if( colorid != COLOR_NONE ) {
         Gtk::ColorSelection* sel = colordiag.get_color_selection();
         sel->set_current_rgba( Gdk::RGBA( CONFIG::get_color( colorid ) ) );
     }
+#endif
     colordiag.set_transient_for( *CORE::get_mainwindow() );
     const int ret = colordiag.run();
 
@@ -674,8 +684,13 @@ void FontColorPref::slot_change_color()
 
             colorid = row[ m_columns_color.m_col_colorid ];
             if( colorid != COLOR_NONE ) {
+#ifdef USE_GTKMM4
+                const Gdk::RGBA rgba = colordiag.get_rgba();
+                CONFIG::set_color( colorid, MISC::color_to_str( rgba ) );
+#else
                 Gtk::ColorSelection* sel = colordiag.get_color_selection();
                 CONFIG::set_color( colorid, MISC::color_to_str( sel->get_current_rgba() ) );
+#endif
             }
         }
     }

--- a/src/jdversion.h
+++ b/src/jdversion.h
@@ -16,8 +16,8 @@
 
 #define MAJORVERSION 0
 #define MINORVERSION 17
-#define MICROVERSION 1
-#define JDDATE_FALLBACK    "20260718"
+#define MICROVERSION 90
+#define JDDATE_FALLBACK    "20260727"
 #define JDTAG     "alpha"
 
 //---------------------------------

--- a/src/linkfilterpref.cpp
+++ b/src/linkfilterpref.cpp
@@ -72,6 +72,9 @@ LinkFilterPref::LinkFilterPref( Gtk::Window* parent, const std::string& url )
     , m_button_bottom( g_dpgettext( GTK_DOMAIN, "Stock label, navigation\x04_Bottom", 24 ), true )
     , m_button_delete( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Delete", 12 ), true )
     , m_button_add( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Add", 12 ), true )
+#ifdef USE_GTKMM4
+    , m_vbuttonbox{ Gtk::ORIENTATION_VERTICAL, 4 }
+#endif
 {
     const bool use_symbolic = CONFIG::get_use_symbolic_icon();
     m_button_top.set_image_from_icon_name( use_symbolic ? "go-top-symbolic" : "go-top" );
@@ -113,8 +116,12 @@ LinkFilterPref::LinkFilterPref( Gtk::Window* parent, const std::string& url )
     m_vbuttonbox.pack_start( m_button_bottom, Gtk::PACK_SHRINK );
     m_vbuttonbox.pack_start( m_button_delete, Gtk::PACK_SHRINK );
     m_vbuttonbox.pack_start( m_button_add, Gtk::PACK_SHRINK );
+#ifdef USE_GTKMM4
+    m_vbuttonbox.set_valign( Gtk::ALIGN_START );
+#else
     m_vbuttonbox.set_layout( Gtk::BUTTONBOX_START );
     m_vbuttonbox.set_spacing( 4 );
+#endif
 
     m_hbox.pack_start( m_scrollwin, Gtk::PACK_EXPAND_WIDGET );
     m_hbox.pack_start( m_vbuttonbox, Gtk::PACK_SHRINK );

--- a/src/linkfilterpref.h
+++ b/src/linkfilterpref.h
@@ -65,7 +65,11 @@ namespace CORE
         Gtk::Button m_button_bottom;
         Gtk::Button m_button_delete;
         Gtk::Button m_button_add;
+#ifdef USE_GTKMM4
+        Gtk::Box m_vbuttonbox;
+#else
         Gtk::VButtonBox m_vbuttonbox;
+#endif
 
         Gtk::HBox m_hbox;
 

--- a/src/setupwizard.cpp
+++ b/src/setupwizard.cpp
@@ -341,9 +341,21 @@ SetupWizard::SetupWizard()
     set_position( Gtk::WIN_POS_CENTER ); // 配置はデスクトップ環境次第
 
     // ボタン
+#ifdef USE_GTKMM4
+    // TODO: GTK4では Gtk::Dialog::get_action_area() が削除されている。
+    // 現時点ではコンパイル可能にすることを優先し、
+    // ボタンは content_area に配置する。
+    // ボタン配置の最終調整は GTK4 UI 移行時に行う。
+    auto hbox = Gtk::make_managed<Gtk::Box>( Gtk::ORIENTATION_HORIZONTAL, SPACING_SIZE / 2 );
+    hbox->set_halign( Gtk::ALIGN_END );
+    hbox->pack_start( m_back );
+    hbox->pack_start( m_next );
+    get_content_area()->pack_end( *hbox );
+#else
     get_action_area()->set_spacing( SPACING_SIZE / 2 );
     get_action_area()->pack_start( m_back, Gtk::PACK_SHRINK );
     get_action_area()->pack_start( m_next, Gtk::PACK_SHRINK );
+#endif
     m_fin = add_button( "完了(_C)", Gtk::RESPONSE_OK );
 
     m_back.set_sensitive( false );

--- a/src/skeleton/aamenu.cpp
+++ b/src/skeleton/aamenu.cpp
@@ -24,11 +24,15 @@ AAMenu::AAMenu( Gtk::Window& parent )
 
     Pango::FontDescription pfd( CONFIG::get_fontname( FONT_MESSAGE ) );
     pfd.set_weight( Pango::WEIGHT_NORMAL );
+#ifndef USE_GTKMM4
+    // GTK4ではoverride_*()が廃止されているため、フェーズ1では省略する。
+    // TODO: GTK4 StyleContext/CssProvider等を利用したスタイル設定に移行する。
     m_textview.override_font( pfd );
     m_textview.override_color( Gdk::RGBA( CONFIG::get_color( COLOR_CHAR_SELECTION ) ),
                                Gtk::STATE_FLAG_NORMAL );
     m_textview.override_background_color( Gdk::RGBA( CONFIG::get_color( COLOR_BACK_SELECTION ) ),
                                           Gtk::STATE_FLAG_NORMAL );
+#endif
 
     m_popup.set_transient_for( m_parent );
     m_popup.sig_configured().connect( sigc::mem_fun( *this, &AAMenu::slot_configured_popup ) );

--- a/src/skeleton/aboutdiag.cpp
+++ b/src/skeleton/aboutdiag.cpp
@@ -27,6 +27,9 @@ enum
 AboutDiag::AboutDiag( const Glib::ustring& title )
     : Gtk::Dialog( title, ENVIRONMENT::get_dialog_use_header_bar() ? Gtk::DIALOG_USE_HEADER_BAR
                                                                    : Gtk::DialogFlags{} )
+#ifdef USE_GTKMM4
+    , m_hbuttonbox_environment{ Gtk::ORIENTATION_HORIZONTAL, 0 }
+#endif
     , m_button_copy_environment( "クリップボードへコピー" )
 {
     set_transient_for( *CORE::get_mainwindow() );
@@ -129,7 +132,11 @@ void AboutDiag::init()
 
     // クリップボードへコピーのボタン
     m_button_copy_environment.signal_clicked().connect( sigc::mem_fun( *this, &AboutDiag::slot_copy_environment ) );
+#ifdef USE_GTKMM4
+    m_hbuttonbox_environment.set_halign( Gtk::ALIGN_END );
+#else
     m_hbuttonbox_environment.set_layout( Gtk::BUTTONBOX_END );
+#endif
     m_hbuttonbox_environment.pack_start( m_button_copy_environment, Gtk::PACK_SHRINK );
     m_vbox_environment.pack_start( m_hbuttonbox_environment, Gtk::PACK_SHRINK );
 

--- a/src/skeleton/aboutdiag.h
+++ b/src/skeleton/aboutdiag.h
@@ -33,7 +33,11 @@ namespace SKELETON
         // 動作環境タブ
         Gtk::Label m_label_tab_environment;
         Gtk::VBox m_vbox_environment;
+#ifdef USE_GTKMM4
+        Gtk::Box m_hbuttonbox_environment;
+#else
         Gtk::HButtonBox m_hbuttonbox_environment;
+#endif
 		Gtk::Button m_button_copy_environment;
         Gtk::ScrolledWindow m_scrollwindow_environment;
         Gtk::TreeView m_treeview_environment;

--- a/src/skeleton/compentry.h
+++ b/src/skeleton/compentry.h
@@ -62,7 +62,9 @@ namespace SKELETON
 
         void modify_font( const Pango::FontDescription& pfd )
         {
+#ifndef USE_GTKMM4
             m_entry.override_font( pfd );
+#endif
         }
 
       private:

--- a/src/skeleton/dragtreeview.cpp
+++ b/src/skeleton/dragtreeview.cpp
@@ -150,7 +150,9 @@ void DragTreeView::init_font( const std::string& fontname )
 {
     Pango::FontDescription pfd( fontname );
     pfd.set_weight( Pango::WEIGHT_NORMAL );
+#ifndef USE_GTKMM4
     override_font( pfd );
+#endif
 }
 
 

--- a/src/skeleton/editview.h
+++ b/src/skeleton/editview.h
@@ -153,7 +153,9 @@ namespace SKELETON
 
         void modify_font( const Pango::FontDescription& font_desc )
         {
+#ifndef USE_GTKMM4
             m_textview.override_font( font_desc );
+#endif
         }
 
         void focus_view(){ m_textview.grab_focus(); }

--- a/src/skeleton/prefdiag.cpp
+++ b/src/skeleton/prefdiag.cpp
@@ -31,7 +31,18 @@ PrefDiag::PrefDiag( Gtk::Window* parent, const std::string& url, const bool add_
             get_header_bar()->pack_start( m_bt_apply );
         }
         else {
+#ifdef USE_GTKMM4
+            // TODO: GTK4では Gtk::Dialog::get_action_area() が削除されている。
+            // 現時点ではコンパイル可能にすることを優先し、
+            // ボタンは content_area に配置する。
+            // ボタン配置の最終調整は GTK4 UI 移行時に行う。
+            auto hbox = Gtk::make_managed<Gtk::Box>();
+            hbox->set_halign( Gtk::ALIGN_END );
+            hbox->pack_start( m_bt_apply );
+            get_content_area()->pack_end( *hbox );
+#else
             get_action_area()->pack_start( m_bt_apply );
+#endif
         }
     }
 

--- a/src/skeleton/selectitempref.cpp
+++ b/src/skeleton/selectitempref.cpp
@@ -24,7 +24,14 @@ SelectItemPref::SelectItemPref( Gtk::Window* parent, const std::string& url )
     , m_button_up( g_dpgettext( GTK_DOMAIN, "Stock label, navigation\x04_Up", 24 ), true )
     , m_button_down( g_dpgettext( GTK_DOMAIN, "Stock label, navigation\x04_Down", 24 ), true )
     , m_button_bottom( g_dpgettext( GTK_DOMAIN, "Stock label, navigation\x04_Bottom", 24 ), true )
+#ifdef USE_GTKMM4
+    , m_vbuttonbox_v{ Gtk::ORIENTATION_VERTICAL, 4 }
+    , m_vbuttonbox_h{ Gtk::ORIENTATION_VERTICAL, 4 }
+#endif
     , m_button_default( g_dpgettext( GTK_DOMAIN, "Stock label\x04_Revert", 12 ), true )
+#ifdef USE_GTKMM4
+    , m_vbuttonbox_action{ Gtk::ORIENTATION_VERTICAL, 4 }
+#endif
 {
     m_list_default_data.clear();
 
@@ -110,16 +117,30 @@ void SelectItemPref::pack_widgets()
 
     m_hbox.pack_start( m_scroll_shown, Gtk::PACK_EXPAND_WIDGET );
 
+#ifdef USE_GTKMM4
+    m_vbuttonbox_v.set_valign( Gtk::ALIGN_START );
+#else
     m_vbuttonbox_v.set_layout( Gtk::BUTTONBOX_START );
     m_vbuttonbox_v.set_spacing( 4 );
+#endif
     m_vbox.pack_start( m_vbuttonbox_v, Gtk::PACK_EXPAND_WIDGET );
 
+#ifdef USE_GTKMM4
+    // TODO: GTK4 - Gtk::BUTTONBOX_EDGE の再現（set_valign では端寄せができないため、
+    // 実際に画面描画を確認するフェーズで CSS/Grid または伸縮用 Spacer Box の追加を検討する）
+    m_vbuttonbox_h.set_valign( Gtk::ALIGN_FILL );
+#else
     m_vbuttonbox_h.set_layout( Gtk::BUTTONBOX_EDGE );
     m_vbuttonbox_h.set_spacing( 4 );
+#endif
     m_vbox.pack_start( m_vbuttonbox_h, Gtk::PACK_SHRINK );
 
+#ifdef USE_GTKMM4
+    m_vbuttonbox_action.set_valign( Gtk::ALIGN_END );
+#else
     m_vbuttonbox_action.set_layout( Gtk::BUTTONBOX_END );
     m_vbuttonbox_action.set_spacing( 4 );
+#endif
     m_vbox.pack_start( m_vbuttonbox_action, Gtk::PACK_EXPAND_WIDGET );
 
     m_hbox.pack_start( m_vbox, Gtk::PACK_SHRINK, 4 );

--- a/src/skeleton/selectitempref.h
+++ b/src/skeleton/selectitempref.h
@@ -49,14 +49,26 @@ namespace SKELETON
         Gtk::Button m_button_up;
         Gtk::Button m_button_down;
         Gtk::Button m_button_bottom;
+#ifdef USE_GTKMM4
+        Gtk::Box m_vbuttonbox_v;
+#else
         Gtk::VButtonBox m_vbuttonbox_v;
+#endif
         // ボタン(横移動)
         Gtk::Button m_button_delete;
         Gtk::Button m_button_add;
+#ifdef USE_GTKMM4
+        Gtk::Box m_vbuttonbox_h;
+#else
         Gtk::VButtonBox m_vbuttonbox_h;
+#endif
         // ボタン(アクション)
         Gtk::Button m_button_default;
+#ifdef USE_GTKMM4
+        Gtk::Box m_vbuttonbox_action;
+#else
         Gtk::VButtonBox m_vbuttonbox_action;
+#endif
 
         // まとめ( m_vbuttonbox_* )
         Gtk::VBox m_vbox;

--- a/src/skeleton/tablabel.cpp
+++ b/src/skeleton/tablabel.cpp
@@ -113,9 +113,13 @@ int TabLabel::get_label_margin() const
 {
     int label_margin;
 
+#ifdef USE_GTKMM4
+    label_margin = m_label.get_margin_start() + m_label.get_margin_end()
+#else
     int x_pad, y_pad;
     m_label.get_padding( x_pad, y_pad );
     label_margin = x_pad*2
+#endif
         + m_hbox.get_spacing() + m_hbox.get_border_width()*2
         + get_border_width()*2;
 

--- a/src/skeleton/toolmenubutton.cpp
+++ b/src/skeleton/toolmenubutton.cpp
@@ -46,13 +46,16 @@ ToolMenuButton::ToolMenuButton( SKELETON::MenuButton* button, const std::string&
     Gtk::Image* image = dynamic_cast< Gtk::Image* >( label_widget );
     if( image ){
         const Gtk::ImageType type = image->get_storage_type();
+#ifndef USE_GTKMM4
         if( type == Gtk::IMAGE_STOCK ) {
             Gtk::StockID id;
             Gtk::IconSize size;
             image->get_stock( id, size );
             item = Gtk::manage( new Gtk::ImageMenuItem( *Gtk::manage( new Gtk::Image( id, size ) ), label ) );
         }
-        else if( type == Gtk::IMAGE_PIXBUF ) {
+        else
+#endif
+        if( type == Gtk::IMAGE_PIXBUF ) {
             auto pixbuf = image->get_pixbuf();
             item = Gtk::manage( new Gtk::ImageMenuItem( *Gtk::manage( new Gtk::Image( pixbuf ) ), label ) );
         }


### PR DESCRIPTION
# GTKMM4移行作業の開始

GTKMM4への移行作業を開始するための準備を行います。

このPull Requestは、上流リポジトリのmasterブランチからforkした個人リポジトリ上で、`gtkmm4-migration` ブランチを使って移行作業を進めるためのdraft Pull Requestです。

**現時点では移行作業の途中であり、ビルドが失敗する状態を意図的に許容しています。**

## 目的

GTKMM4移行に向けて、まずGTKMM4で削除・変更されたAPIの影響範囲を把握し、GTKMM4への切り替え前に移行の障害となるコードを減らします。

移行作業中は、通常の機能追加や変更、バグ修正などの対応を縮小します。

## 現在の構成

### 移行作業ブランチ

`gtkmm4-migration`

予告なく rebase や force push を行いますので注意してください。

### ビルドオプション

```text
-Duse_gtkmm4=true
```

`use_gtkmm4` はデフォルトでは `false` です。

現段階では `use_gtkmm4=true` にしてもGTKMM4そのものには切り替えず、GTKMM3を使用したままdeprecated APIをコンパイルエラーとして検出します。

### CI

GTKMM4移行用CIでは、以下を行います。

* 通常のビルド構成が壊れていないか確認
* `use_gtkmm4=true` で移行対象コードをビルド
* GCCの診断メッセージをJSON形式で収集
* コンパイルエラー・警告を集計
* GitHub ActionsのStep Summaryに集計結果を表示
* 診断ログと集計結果をアーティファクトとして保存

移行初期段階ではコンパイルエラーが発生することを想定しています。

CIの失敗そのものを問題とするのではなく、診断メッセージの種類と件数を移行作業の進捗確認に利用します。

## バージョン

GTKMM4移行作業中の開発バージョンとして `0.17.90-alpha` を設定しています。

通常のリリースサイクルとは区別し、GTKMM4移行作業中の開発バージョンであることを明確にするための番号です。

## 今後の作業

1. deprecated APIによるコンパイルエラーを解消する
2. GTKMM4への移行に必要なコード変更を進める
3. `use_gtkmm4=true` でGTKMM4を使用したビルドへ切り替える
4. GTKMM4でビルド・動作する状態を目指す
5. 移行完了後に必要な機能の再構築・改善を行う
6. GTKMM3版および移行用の条件分岐を整理する
7. 完成した段階で上流masterへのマージを検討する

移行期間や完成予定日は現時点では設定していません。

まずはGTKMM4で動作する状態を優先し、必要に応じて機能のオミットを許容します。オミットした機能の再構築は、GTKMM4移行完了後の別の課題として扱う予定です。
